### PR TITLE
Single Match Results for Demo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,6 @@ lazy val `address-index-demoui` = project.in(file("demoui"))
     routesGenerator      := InjectedRoutesGenerator
   )
   .dependsOn(
-    `address-index-model`,
-    `address-index-parsers`
+    `address-index-model`
   )
   .enablePlugins(PlayScala, SbtWeb)

--- a/demoui/app/uk/gov/ons/address/ErrorHandler.scala
+++ b/demoui/app/uk/gov/ons/address/ErrorHandler.scala
@@ -4,10 +4,8 @@ import play.api.http.HttpErrorHandler
 import play.api.mvc._
 import play.api.mvc.Results._
 import scala.concurrent._
-import javax.inject.Singleton;
-/**
-  * Created by amits on 10/08/2016.
-  */
+import javax.inject.Singleton
+
 @Singleton
 class ErrorHandler extends HttpErrorHandler {
   // called when a route is found, but it was not possible to bind the request parameters

--- a/demoui/app/uk/gov/ons/address/controllers/SingleMatch.scala
+++ b/demoui/app/uk/gov/ons/address/controllers/SingleMatch.scala
@@ -33,10 +33,11 @@ class SingleMatch @Inject()(
 
   def doSingleMatch() = Action.async { implicit request =>
     val address  = request.body.asFormUrlEncoded.get("address").mkString
-    val street   = request.body.asFormUrlEncoded.get("street").mkString
-    val town     = request.body.asFormUrlEncoded.get("town").mkString
-    val postCode = request.body.asFormUrlEncoded.get("postcode").mkString
-    val inputAddress = address + " " + street + " " + town + " " + postCode
+ //   val street   = request.body.asFormUrlEncoded.get("street").mkString
+ //   val town     = request.body.asFormUrlEncoded.get("town").mkString
+ //   val postCode = request.body.asFormUrlEncoded.get("postcode").mkString
+  //  val inputAddress = address + " " + street + " " + town + " " + postCode
+   val inputAddress = address
     if (inputAddress.trim.isEmpty) {
       logger.debug("Empty input address")
       Future.successful(Ok(

--- a/demoui/app/uk/gov/ons/address/views/main.scala.html
+++ b/demoui/app/uk/gov/ons/address/views/main.scala.html
@@ -12,10 +12,8 @@
         <title>@title</title>
         <script  type="text/javascript" src='@routes.Assets.versioned("/lib/jquery/jquery.min.js")'></script>
         <script  type="text/javascript" src='@routes.Assets.versioned("/lib/bootstrap/js/bootstrap.min.js")'></script>
-        <script  type="text/javascript" src='@routes.Assets.versioned("/lib/jasny-bootstrap/js/jasny-bootstrap.min.js")'></script>
         <link rel='stylesheet' href='@routes.Assets.versioned("/lib/bootstrap/css/bootstrap.min.css")'>
         <link rel='stylesheet' href='@routes.Assets.versioned("/lib/font-awesome/css/font-awesome.min.css")'>
-        <link rel='stylesheet' href='@routes.Assets.versioned("/lib/jasny-bootstrap/css/jasny-bootstrap.min.css")'>
 
         <script type="text/javascript"src='@routes.Assets.versioned("javascript/main.js")'></script>
 

--- a/demoui/app/uk/gov/ons/address/views/singleMatch.scala.html
+++ b/demoui/app/uk/gov/ons/address/views/singleMatch.scala.html
@@ -133,4 +133,80 @@
         </div>
     </div>
 </div>
+<script>
+        var lastadd = '';
+        document.getElementById('address').addEventListener('input', e => {
+            const features = parseAddressFeatures(e.target.value);
+            if (!features) {
+                return;
+            }
+            if  (features == lastadd){
+                return;
+            }
+            lastadd = features;
+            const username = 'demoui';
+            const password = 'qu8cb6tkphlmx8epgq';
+            const query = buildQuery(features.buildingNumber, features.postcode);
+            const queryOptions = buildQueryOptions(username, password, query);
+            const url = 'http://06aee33092e6d4a954130175b435d54b.eu-west-1.aws.found.io:9200/paf/address/_search';
+            fetch(url, queryOptions).then(response => response.json()).then(response => {
+                console.log(response);
+                const container = document.createElement('div');
+                const match = document.createElement('div');
+                const address = response.hits.hits[0]._source;
+                console.log(address);
+                match.innerText = `${address.buildingNumber}, ${address.thoroughfare} ${address.postTown} ${address.postcode}`;
+                document.body.appendChild(container);
+                container.appendChild(match);
+            });
+        });
+
+        function buildQuery(buildingNumber, postcode) {
+            return {
+                "query": {
+                    "bool": {
+                        "must": [{
+                            "match": {
+                                buildingNumber
+                            }
+                        }, {
+                            "match": {
+                                postcode
+                            }
+                        }]
+                    }
+                }
+            };
+        }
+
+        function buildCredentials(username, password) {
+            const credentials = btoa(`${username}:${password}`);
+            return credentials;
+        }
+
+        function buildQueryOptions(username, password, query) {
+            const credentials = buildCredentials(username, password);
+            const headers = {
+                authorization: `Basic ${credentials}`,
+            };
+            const options = {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(query)
+            };
+            return options;
+        }
+
+        function parseAddressFeatures(s) {
+            const regexp = /^(\d+).*([A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}|GIR 0AA)$/i
+            const matches = regexp.exec(s);
+            if (!matches) {
+                return;
+            }
+            return {
+                buildingNumber: matches[1],
+                postcode: matches[2]
+            }
+        }
+    </script>
 }


### PR DESCRIPTION
This uses Alan's demo script to give results on the single match page.
You need to type in a number and postocde present on the AWS test ES,
e.g 7 EX2 6GA - the search will fire on completion and the expanded
address returned. Clicking the Search button will either give you the
"no address" error if the box is empty, or timeout  as the API is not
there yet.