### PR TITLE
Added sbt-native-packager for building deployments

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,4 @@ logLevel := Level.Warn
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"           % "2.5.9")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"         % "0.14.3")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"  % "1.1.4")


### PR DESCRIPTION
The default packager does not build compatible binaries for cloud foundry due to path names that are too long.  
sbt-native-packager compiles the package differently and it has been tested to work with cloud foundry with a successful deployment.