### PR TITLE
Remove whitespace from version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version=0.13.8


### PR DESCRIPTION
The SBT version on Dev3 doesn't expect whitespace in the sbt.version configuration line