### PR TITLE
Update application.conf

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -19,7 +19,7 @@ addressIndex {
     shieldSsl = true
     shieldUser = "admin:changeMeImNotTheRealPassword"
     indexes {
-      paf = "paf/address"
+      pafIndex = "paf/address"
     }
   }
 }


### PR DESCRIPTION
Changed paf to pafIndex in application.conf as it has to match the variable in Scala configuration code.

Needs a full review to be sure that we want to change the configuration and not the code.  However, we only need to change the configuration file in one place.

Tested successfully in Cloud Foundry on Dev3.