### PR TITLE
Update application.conf to allow use of ENV labels

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -14,12 +14,17 @@ addressIndex {
   elasticSearch {
     local = false
     cluster = "06aee33092e6d4a954130175b435d54b"
+    cluster = ${?ONS_AI_API_ES_CLUSTER_NAME}
     // if you are using a remote server over SSL, try to use port 9343
     uri = "elasticsearch://06aee33092e6d4a954130175b435d54b.eu-west-1.aws.found.io:9343"
+    uri = ${?ONS_AI_API_ES_URI}
     shieldSsl = true
+    shieldSsl = ${?ONS_AI_API_SHIELD_SSL}
     shieldUser = "admin:changeMeImNotTheRealPassword"
+    shieldUser = ${?ONS_AI_API_SHIELD_USER}
     indexes {
       pafIndex = "paf/address"
+      pafIndex = ${?ONS_AI_API_PAF_INDEX}
     }
   }
 }


### PR DESCRIPTION
For deploying on Cloud Foundry we can use Environment Labels to specify the parameters used for elastic search with the API.

Tested in ONS Cloud Foundry