### PR TITLE
Release/ai261

### DIFF
--- a/client/src/main/scala/uk/gov/ons/addressIndex/client/AddressIndexClient.scala
+++ b/client/src/main/scala/uk/gov/ons/addressIndex/client/AddressIndexClient.scala
@@ -33,7 +33,9 @@ trait AddressIndexClient {
       .toReq
       .withQueryString(
         "input" -> request.input,
-        "format" -> request.format.toString
+        "format" -> request.format.toString,
+        "limit" -> request.limit,
+        "offset" -> request.offset
       )
       .get
       .map(_.json.as[AddressBySearchResponseContainer])

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
@@ -100,6 +100,8 @@ class SingleMatchController @Inject()(
         AddressIndexSearchRequest(
           format = AddressScheme.StringToAddressSchemeAugmenter(formatText).stringToScheme().getOrElse(PostcodeAddressFile("paf")),
           input = addressText,
+          limit = "10",
+          offset = "0",
           id = UUID.randomUUID
         )
       ) map { resp: AddressBySearchResponseContainer =>
@@ -119,6 +121,8 @@ class SingleMatchController @Inject()(
         AddressIndexSearchRequest(
           format = PostcodeAddressFile("paf"),
           input = input,
+          limit = "10",
+          offset = "0",
           id = UUID.randomUUID
         )
       }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -11,6 +11,8 @@ case class AddressIndexUPRNRequest(
 case class AddressIndexSearchRequest(
   format: AddressScheme,
   input: String,
+  limit: String,
+  offset: String,
   id: UUID
 )
 

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -5,7 +5,11 @@ case class ElasticSearchConfig(
   cluster: String,
   uri: String,
   indexes: IndexesConfig,
-  shield: ShieldConfig
+  shield: ShieldConfig,
+  defaultLimit: Int,
+  defaultOffset: Int,
+  maximumLimit: Int,
+  maximumOffset: Int
 )
 
 object ElasticSearchConfig {
@@ -21,7 +25,11 @@ object ElasticSearchConfig {
       ssl = true,
       user = "admin",
       password = ""
-    )
+    ),
+    defaultLimit=10,
+    defaultOffset=0,
+    maximumLimit=100,
+    maximumOffset=1000
   )
 }
 

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/AddressResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/AddressResponse.scala
@@ -437,7 +437,7 @@ object AddressResponseGeo {
   * @param code    http code
   * @param message response description
   */
-case class AddressResponseStatus(
+case class AddressResponseStatus (
   code: Int,
   message: String
 )
@@ -492,6 +492,35 @@ object NotFoundAddressResponseError extends AddressResponseError(
   message = "UPRN request didn't yield a result"
 )
 
+object LimitNotNumericAddressResponseError extends AddressResponseError(
+  code = 4,
+  message = "Limit parameter not numeric"
+)
+
+object OffsetNotNumericAddressResponseError extends AddressResponseError(
+  code = 5,
+  message = "Offset parameter not numeric"
+)
+
+object LimitTooSmallAddressResponseError extends AddressResponseError(
+  code = 6,
+  message = "Limit parameter too small, minimum = 1"
+)
+
+object OffsetTooSmallAddressResponseError extends AddressResponseError(
+  code = 7,
+  message = "Offset parameter too small, minimum = 0"
+)
+
+object LimitTooLargeAddressResponseError extends AddressResponseError(
+  code = 8,
+  message = "Limit parameter too large (maximum configurable)"
+)
+
+object OffsetTooLargeAddressResponseError extends AddressResponseError(
+  code = 9,
+  message = "Offset parameter too large (maximum configurable)"
+)
 
 
 

--- a/model/src/test/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfigTest.scala
+++ b/model/src/test/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfigTest.scala
@@ -38,6 +38,10 @@ object ElasticSearchConfigTest {
     indexes = IndexesConfig(
       pafIndex = "paf/address",
       nagIndex = "nag/address"
-    )
+    ),
+    defaultLimit=10,
+    defaultOffset=0,
+    maximumLimit=100,
+    maximumOffset=1000
   )
 }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -51,6 +51,7 @@ class AddressController @Inject()(
     val defOffset = conf.config.elasticSearch.defaultOffset
     val maxLimit = conf.config.elasticSearch.maximumLimit
     val maxOffset = conf.config.elasticSearch.maximumOffset
+// TODO Look at refactoring to use types
     val limval = limit.getOrElse(defLimit.toString())
     val offval = offset.getOrElse(defOffset.toString())
     val limitInvalid = Try(limval.toInt).isFailure
@@ -101,5 +102,11 @@ class AddressController @Inject()(
       inputForNagFn = UprnQueryInput(uprn),
       nagFn = uprnNagSearch
     ) getOrElse futureJsonBadRequest(UnsupportedFormatUprn)
+  }
+}
+
+case class MyType(message: String) {
+  def validate (opt: Option[Int]): MyType = {
+    opt.map { number => if(number > 10) { MyType("something1")} else {MyType("something2")} }.getOrElse(MyType("default"))
   }
 }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -104,9 +104,3 @@ class AddressController @Inject()(
     ) getOrElse futureJsonBadRequest(UnsupportedFormatUprn)
   }
 }
-
-case class MyType(message: String) {
-  def validate (opt: Option[Int]): MyType = {
-    opt.map { number => if(number > 10) { MyType("something1")} else {MyType("something2")} }.getOrElse(MyType("default"))
-  }
-}

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -54,7 +54,7 @@ class AddressController @Inject()(
     val limval = limit.getOrElse(defLimit.toString())
     val offval = offset.getOrElse(defOffset.toString())
     val limitInvalid = Try(limval.toInt).isFailure
-    val offsetInvalid = Try(limval.toInt).isFailure
+    val offsetInvalid = Try(offval.toInt).isFailure
     val limitInt = Try(limval.toInt).toOption.getOrElse(defLimit)
     val offsetInt = Try(offval.toInt).toOption.getOrElse(defOffset)
 // Check the offset and limit parameters before proceeding with the request

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexActions.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexActions.scala
@@ -39,7 +39,9 @@ trait AddressIndexActions { self: AddressIndexCannedResponse with PlayHelperCont
       searchContainerTemplate(
         tokens = tokens.input,
         addresses = addresses map(AddressResponseAddress fromPafAddress maxScore),
-        total = addresses.size
+        total = addresses.size,
+        limit = tokens.limit,
+        offset = tokens.offset - 1
       )
     }
   }
@@ -53,7 +55,9 @@ trait AddressIndexActions { self: AddressIndexCannedResponse with PlayHelperCont
       searchContainerTemplate(
         tokens = tokens.input,
         addresses = addresses map(AddressResponseAddress fromNagAddress maxScore),
-        total = addresses.size
+        total = addresses.size,
+        limit = tokens.limit,
+        offset = tokens.offset - 1
       )
     }
   }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
@@ -5,12 +5,12 @@ import uk.gov.ons.addressIndex.model.server.response._
 
 trait AddressIndexCannedResponse {
 
-  def Limit: Int = 10
-
   def searchContainerTemplate(
     tokens: Seq[CrfTokenResult],
     addresses: Seq[AddressResponseAddress],
-    total: Int
+    total: Int,
+    limit: Int,
+    offset: Int
   ): AddressBySearchResponseContainer = {
     AddressBySearchResponseContainer(
       response = AddressBySearchResponse(
@@ -22,8 +22,8 @@ trait AddressIndexCannedResponse {
             )
           }.toSeq,
         addresses = addresses,
-        limit = Limit,
-        offset = 0,
+        limit = limit,
+        offset = offset,
         total = addresses.size
       ),
       status = OkAddressResponseStatus
@@ -127,7 +127,7 @@ trait AddressIndexCannedResponse {
     AddressBySearchResponse(
       Seq.empty,
       addresses = Seq.empty,
-      limit = Limit,
+      limit = 10,
       offset = 0,
       total = 0
     )

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
@@ -59,68 +59,44 @@ trait AddressIndexCannedResponse {
     )
   }
 
-  def LimitNotNumeric: AddressBySearchResponseContainer = {
+  private def BadRequestTemplate(errors: AddressResponseError*): AddressBySearchResponseContainer = {
     AddressBySearchResponseContainer(
       response = Error,
       status = BadRequestAddressResponseStatus,
-      errors = Seq(LimitNotNumericAddressResponseError)
+      errors = errors
     )
   }
 
   def OffsetNotNumeric: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(OffsetNotNumericAddressResponseError)
-    )
+    BadRequestTemplate(OffsetNotNumericAddressResponseError)
+  }
+
+  def LimitNotNumeric: AddressBySearchResponseContainer = {
+    BadRequestTemplate(LimitNotNumericAddressResponseError)
   }
 
   def LimitTooSmall: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(LimitTooSmallAddressResponseError)
-    )
+      BadRequestTemplate(LimitTooSmallAddressResponseError)
   }
 
   def OffsetTooSmall: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(OffsetTooSmallAddressResponseError)
-    )
+      BadRequestTemplate(OffsetTooSmallAddressResponseError)
   }
 
   def LimitTooLarge: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(LimitTooLargeAddressResponseError)
-    )
+      BadRequestTemplate(LimitTooLargeAddressResponseError)
   }
 
   def OffsetTooLarge: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(OffsetTooLargeAddressResponseError)
-    )
+      BadRequestTemplate(OffsetTooLargeAddressResponseError)
   }
 
   def UnsupportedFormat: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(FormatNotSupportedAddressResponseError)
-    )
+      BadRequestTemplate(FormatNotSupportedAddressResponseError)
   }
 
   def EmptySearch: AddressBySearchResponseContainer = {
-    AddressBySearchResponseContainer(
-      response = Error,
-      status = BadRequestAddressResponseStatus,
-      errors = Seq(EmptyQueryAddressResponseError)
-    )
+      BadRequestTemplate(EmptyQueryAddressResponseError)
   }
 
   def Error: AddressBySearchResponse = {

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexCannedResponse.scala
@@ -59,6 +59,54 @@ trait AddressIndexCannedResponse {
     )
   }
 
+  def LimitNotNumeric: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(LimitNotNumericAddressResponseError)
+    )
+  }
+
+  def OffsetNotNumeric: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(OffsetNotNumericAddressResponseError)
+    )
+  }
+
+  def LimitTooSmall: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(LimitTooSmallAddressResponseError)
+    )
+  }
+
+  def OffsetTooSmall: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(OffsetTooSmallAddressResponseError)
+    )
+  }
+
+  def LimitTooLarge: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(LimitTooLargeAddressResponseError)
+    )
+  }
+
+  def OffsetTooLarge: AddressBySearchResponseContainer = {
+    AddressBySearchResponseContainer(
+      response = Error,
+      status = BadRequestAddressResponseStatus,
+      errors = Seq(OffsetTooLargeAddressResponseError)
+    )
+  }
+
   def UnsupportedFormat: AddressBySearchResponseContainer = {
     AddressBySearchResponseContainer(
       response = Error,

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -44,7 +44,7 @@ trait ElasticsearchRepository {
     * @param tokens address tokens
     * @return Future with found PAF addresses and the maximum score
     */
-  def queryPafAddresses(tokens: Seq[CrfTokenResult]) : Future[PostcodeAddressFileAddresses]
+  def queryPafAddresses(start: Int, limit: Int, tokens: Seq[CrfTokenResult]) : Future[PostcodeAddressFileAddresses]
 
   /**
     * Query the address index for NAG addresses.
@@ -53,7 +53,7 @@ trait ElasticsearchRepository {
     * @param tokens address tokens
     * @return Future with found PAF addresses and the maximum score
     */
-  def queryNagAddresses(tokens: Seq[CrfTokenResult]) : Future[NationalAddressGazetteerAddresses]
+  def queryNagAddresses(start: Int, limit: Int, tokens: Seq[CrfTokenResult]) : Future[NationalAddressGazetteerAddresses]
 }
 
 @Singleton
@@ -99,9 +99,9 @@ class AddressIndexRepository @Inject()(
     }
   }
 
-  def queryPafAddresses(tokens: Seq[CrfTokenResult]): Future[PostcodeAddressFileAddresses] = {
+  def queryPafAddresses(start: Int, limit: Int, tokens: Seq[CrfTokenResult]): Future[PostcodeAddressFileAddresses] = {
     client execute {
-      val s = search in pafIndex query {
+      val s = search in pafIndex start start limit limit query {
         bool(
           must(
             tokensToMatchQueries(
@@ -131,9 +131,9 @@ class AddressIndexRepository @Inject()(
     }
   }
 
-  def queryNagAddresses(tokens: Seq[CrfTokenResult]): Future[NationalAddressGazetteerAddresses] = {
+  def queryNagAddresses(start: Int, limit: Int, tokens: Seq[CrfTokenResult]): Future[NationalAddressGazetteerAddresses] = {
     client execute {
-      val s = search in nagIndex query {
+      val s = search in nagIndex start start limit limit query {
         bool(
           must(
             tokensToMatchQueries(

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -32,5 +32,9 @@ addressIndex {
       nagIndex = "nag/address"
       nagIndex = ${?ONS_AI_API_NAG_INDEX}
     }
+    defaultLimit=10
+    defaultOffset=0
+    maximumLimit=100
+    maximumOffset=1000
   }
 }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -4,7 +4,7 @@
 GET     /                   uk.gov.ons.addressIndex.server.controllers.general.ApplicationController.index
 
 #EG     /addresses?format=myFormat&input=myInputString
-GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, format)
+GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, format, offset: Option[String], limit: Option[String])
 
 #EG     /addresses/myUprn?format=myFormat
 GET     /addresses/:uprn    uk.gov.ons.addressIndex.server.controllers.AddressController.uprnQuery(uprn, format)

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -323,7 +323,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
       val expected = expectedPaf.copy(score = expectedScore)
 
       // When
-      val PostcodeAddressFileAddresses(results, maxScore) = repository.queryPafAddresses(tokens).await
+      val PostcodeAddressFileAddresses(results, maxScore) = repository.queryPafAddresses(1,10,tokens).await
 
       // Then
       results.length shouldBe 1
@@ -344,7 +344,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
       val expected = expectedNag.copy(score = expectedScore)
 
       // When
-      val NationalAddressGazetteerAddresses(results, maxScore) = repository.queryNagAddresses(tokens).await
+      val NationalAddressGazetteerAddresses(results, maxScore) = repository.queryNagAddresses(1,10,tokens).await
 
       // Then
       results.length shouldBe 1


### PR DESCRIPTION
This change is to implement story 261 - paging parameters in the API, example URL http://localhost:9001/addresses?input=3%20EXETER%20EX2&format=bs&limit=10&offset=2

The limit and offset parameters are optional. Defaults and maxima are set in the application.conf.

Both parameters are checked for being numeric, less than the maximum and at least the minimum (0 for offset, 1 for limit). A Bad Request (400) is returned in each case with meaningful text.

The offset is incremented by 1 to become elastic4s's start value.

Offset, limit and size are returned in the response. If the offset is greater than the total number of results, it is not an error, rather size will be zero.