### PR TITLE
AW patch/crf tagger string

### DIFF
--- a/tagger/crftagger/Makefile
+++ b/tagger/crftagger/Makefile
@@ -5,6 +5,7 @@ RMF=rm -f
 LIB=$(HOME)/local/lib
 CCFLAGS=-fPIC -DHAVE_CONFIG_H -mfpmath=sse -msse2 -DUSE_SSE -O3 -fomit-frame-pointer -ffast-math -Winline -std=c99 -MT crftagger.o -MD -MP -c
 OBJ=crftagger.o crfjni.o iwa.o
+LIB_OPTIONS=-l:libcrfsuite.a -l:libcqdb.a -l:liblbfgs.a
 
 ifeq ($(OS),Windows)
 	CC=x86_64-w64-mingw32-gcc

--- a/tagger/crftagger/Makefile
+++ b/tagger/crftagger/Makefile
@@ -4,6 +4,7 @@ RMF=rm -f
 
 LIB=$(HOME)/local/lib
 CCFLAGS=-fPIC -DHAVE_CONFIG_H -mfpmath=sse -msse2 -DUSE_SSE -O3 -fomit-frame-pointer -ffast-math -Winline -std=c99 -MT crftagger.o -MD -MP -c
+OBJ=crftagger.o crfjni.o iwa.o
 
 ifeq ($(OS),Windows)
 	CC=x86_64-w64-mingw32-gcc
@@ -19,8 +20,6 @@ else
 		$(LIB)/libcqdb*.dylib $(LIB)/libcqdb*.la \
 		$(LIB)/libcrfsuite*.dylib $(LIB)/libcrfsuite*.la \
 		$(LIB)/liblbfgs*.dylib $(LIB)/liblbfgs*.la
-
-	OBJ=crftagger.o crfjni.o iwa.o
 
 	ifeq ($(UNAME),Darwin)
 		TARGET=libcrftagger-osx.so

--- a/tagger/crftagger/Makefile
+++ b/tagger/crftagger/Makefile
@@ -38,7 +38,7 @@ endif
 	$(CC) $(CCFLAGS) $< -o $@
 
 $(TARGET): $(OBJ)
-	$(RM_DYNAMIC_LIBS)
+	$(RMF_DYNAMIC_LIBS)
 	$(CC) $^ -shared -o $@ -L$(LIB) $(LIB_OPTIONS)
 
 all: $(TARGET)


### PR DESCRIPTION
Needs to change the makefile to get it to compile for windows.  You @alangorton may want to change the scope of some of the variables.  Checked on Jenkins and builds DLL correctly.