### PR TITLE
align PAF/NAG and score, fix page number error

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/pager.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/pager.scala.html
@@ -8,7 +8,7 @@
             @{Some(pageNum-1)} of @{Math.min(pageMax, (numResults + pageSize - 1) / pageSize)}</a>
         </div>
         <div class="pagecentre"> <br>Page @{pageNum}</div>
-        <div class="pageright pr@{ (pageNum == (numResults / pageSize)) || pageNum == pageMax }">
+        <div class="pageright pr@{ (pageNum == ((numResults + pageSize - 1) / pageSize)) || pageNum == pageMax }">
             <a href='@{uk.gov.ons.addressIndex.demoui.controllers.routes.SingleMatchController.doMatchWithInput(address, addressFormat, Some(pageNum+1))}'>
             Next page &gt;<br>
             @{Some(pageNum+1)} of @{Math.min(pageMax, (numResults + pageSize - 1) / pageSize)}</a>

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/singleMatch.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/singleMatch.scala.html
@@ -73,18 +73,19 @@
                     <div class="alert alert-success">
                         <div class="matchResults">
                             <div class="resultRow">
-                                  <div id="match-score" class="match-conf">@messages("single.matchscore"): @("%.2f".format(address.underlyingScore))
-                                    (
-                                    @defining(if ((address.underlyingScore / aresponse.maxScore) * 100 > 70) "#c6ffb3" else "#ffcccc") { color =>
-                                    <span style="background-color: @color">
-                                    }
-                                    @{"%.2f".format((address.underlyingScore / aresponse.maxScore) * 100)}</span>%)</div>
-                            </div>
-                            <div class="resultRow">
                                 <div class="paf-nag-switch-buttons">
                                     <span class="formatted-nag-button formatted-button-active">LA</span>
                                     <span class="formatted-paf-button">PAF</span>
                                 </div>
+                                 <div id="match-score" class="match-conf">@messages("single.matchscore"): @("%.2f".format(address.underlyingScore))
+                                    (
+                                    @defining(if ((address.underlyingScore / aresponse.maxScore) * 100 > 70) "#c6ffb3" else "#ffcccc") { color =>
+                                    <span style="background-color: @color">
+                                    }
+                                    @{"%.2f".format((address.underlyingScore / aresponse.maxScore) * 100)}</span>%)
+                                 </div>
+                              </div>
+                            <div class="resultRow">
                                 <div>
                                     <strong>@messages("single.address"): </strong>
                                     <span class="formatted-nag">@address.formattedAddressNag</span>

--- a/demo-ui/public/stylesheets/ons.css
+++ b/demo-ui/public/stylesheets/ons.css
@@ -91,7 +91,7 @@ p.toptext {
     margin-top: 0px;
     margin-bottom: 10px;
     min-width: 300px;
-    max-width: 900px;
+    max-width: 800px;
     border-bottom:2px solid #ddd;
     border-top: 0px;
     border-left: 0px;
@@ -331,8 +331,8 @@ div.matchResults{
 div.match-conf{
     text-align:right;
     white-space:nowrap;
-    float: left;
-    width: 100%;
+    float: right;
+    width: 50%;
 }
 
 div.uprn-txt{
@@ -375,15 +375,15 @@ p.errorBody{
 
 div.paf-nag-switch-buttons{
     color: #aaa;
-    display: inline-block;
+    text-align:left;
     background: #eee;
     padding: 5px 6px;
+    float:left;
 }
+
 div.paf-nag-switch-buttons span{
-    display: inline-block;
     padding: 0px 10px;
     border: 1px solid #999;
-
 }
 
 .formatted-button-active{

--- a/demo-ui/public/stylesheets/ons.css
+++ b/demo-ui/public/stylesheets/ons.css
@@ -388,10 +388,12 @@ div.paf-nag-switch-buttons span{
 
 .formatted-button-active{
     background-color: #00914E;
+    color: #fff;
 }
 
 div.paf-nag-switch-buttons span:hover{
     background-color: #00914E;
+    color: #fff;
     cursor:pointer;
 }
 


### PR DESCRIPTION
Small UI change to make PAF/NAG buttons and matching score coexist on the same row (Taiwo spotted this) and another change to the paging view so that the maximum page number for the next page is correctly processed when it is less than 100.