### PR TITLE
Replaces `must` with `should` as that `must` does not work on objects…

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -218,7 +218,7 @@ class AddressIndexRepository @Inject()(
           field = "lpi.streetDescriptor",
           value = token
         ).boost(queryParams.streetName.lpiStreetDescriptorBoost))
-    ).flatten.map(_.fuzziness("2"))
+    ).flatten.map(_.fuzziness("1"))
 
     val townNameQuery = Seq(
       tokens.get(Tokens.townName).map(token =>
@@ -261,7 +261,7 @@ class AddressIndexRepository @Inject()(
           field = "paf.welshDoubleDependentLocality",
           value = token
         ).boost(queryParams.townName.pafWelshDoubleDependentLocalityBoost))
-    ).flatten.map(_.fuzziness("2"))
+    ).flatten.map(_.fuzziness("1"))
 
     val postcodeQuery = Seq(
       tokens.get(Tokens.postcode).map(token =>
@@ -281,12 +281,12 @@ class AddressIndexRepository @Inject()(
         matchQuery(
           field = "postcodeOut",
           value = token
-        ).boost(queryParams.postcode.postcodeOutBoost).fuzziness("1")),
+        ).boost(queryParams.postcode.postcodeOutBoost)),
       tokens.get(Tokens.postcodeIn).map(token =>
         matchQuery(
           field = "postcodeIn",
           value = token
-        ).boost(queryParams.postcode.postcodeInBoost).fuzziness("2"))
+        ).boost(queryParams.postcode.postcodeInBoost))
     ).flatten
 
     val organisationNameQuery = Seq(
@@ -356,7 +356,7 @@ class AddressIndexRepository @Inject()(
           field = "paf.welshDoubleDependentLocality",
           value = token
         ).boost(queryParams.locality.pafWelshDoubleDependentLocalityBoost))
-    ).flatten.map(_.fuzziness("2"))
+    ).flatten.map(_.fuzziness("1"))
 
     val allQuery = Seq(
       matchQuery(
@@ -389,9 +389,9 @@ class AddressIndexRepository @Inject()(
 
     val preciseQuery = (preciseMustQuery, preciseShouldQuery) match {
       case (Nil, Nil) => Seq.empty
-      case (mustQuery, Nil) => Seq(must(mustQuery))
+      case (mustQuery, Nil) => Seq(should(mustQuery))
       case (Nil, shouldQuery) => Seq(should(shouldQuery))
-      case (mustQuery, shouldQuery) => Seq(must(mustQuery), should(shouldQuery))
+      case (mustQuery, shouldQuery) => Seq(should(mustQuery), should(shouldQuery))
     }
 
     val fallbackQuery = should(allQuery)

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -539,7 +539,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                             "should":[  
                                {  
                                   "bool":{  
-                                     "must":[  
+                                     "should":[
                                         {  
                                            "bool":{  
                                               "should":[  
@@ -623,7 +623,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagStreetDescriptor",
                                                           "type":"boolean",
                                                           "boost":${queryParams.streetName.pafThoroughfareBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -633,7 +633,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagStreetDescriptor",
                                                           "type":"boolean",
                                                           "boost":${queryParams.streetName.pafWelshThoroughfareBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -643,7 +643,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagStreetDescriptor",
                                                           "type":"boolean",
                                                           "boost":${queryParams.streetName.pafDependentThoroughfareBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -653,7 +653,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagStreetDescriptor",
                                                           "type":"boolean",
                                                           "boost":${queryParams.streetName.pafWelshDependentThoroughfareBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -663,7 +663,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagStreetDescriptor",
                                                           "type":"boolean",
                                                           "boost":${queryParams.streetName.lpiStreetDescriptorBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  }
@@ -679,7 +679,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafPostTownBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -689,7 +689,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafWelshPostTownBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -699,7 +699,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.lpiTownNameBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -709,7 +709,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -719,7 +719,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafWelshDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -729,7 +729,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.lpiLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -739,7 +739,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafDoubleDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -749,7 +749,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagTownName",
                                                           "type":"boolean",
                                                           "boost":${queryParams.townName.pafWelshDoubleDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  }
@@ -788,8 +788,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                        "postcodeOut":{  
                                                           "query":"$hybridFirstPostcodeOut",
                                                           "type":"boolean",
-                                                          "boost":${queryParams.postcode.postcodeOutBoost},
-                                                          "fuzziness":"1"
+                                                          "boost":${queryParams.postcode.postcodeOutBoost}
                                                        }
                                                     }
                                                  },
@@ -798,8 +797,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                        "postcodeIn":{  
                                                           "query":"$hybridFirstPostcodeIn",
                                                           "type":"boolean",
-                                                          "boost":${queryParams.postcode.postcodeInBoost},
-                                                          "fuzziness":"2"
+                                                          "boost":${queryParams.postcode.postcodeInBoost}
                                                        }
                                                     }
                                                  }
@@ -980,7 +978,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagLocality",
                                                           "type":"boolean",
                                                           "boost":${queryParams.locality.pafDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -990,7 +988,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagLocality",
                                                           "type":"boolean",
                                                           "boost":${queryParams.locality.pafWelshDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -1000,7 +998,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagLocality",
                                                           "type":"boolean",
                                                           "boost":${queryParams.locality.lpiLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -1010,7 +1008,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagLocality",
                                                           "type":"boolean",
                                                           "boost":${queryParams.locality.pafDoubleDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  },
@@ -1020,7 +1018,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
                                                           "query":"$hybridNagLocality",
                                                           "type":"boolean",
                                                           "boost":${queryParams.locality.pafWelshDoubleDependentLocalityBoost},
-                                                          "fuzziness":"2"
+                                                          "fuzziness":"1"
                                                        }
                                                     }
                                                  }


### PR DESCRIPTION
…… (#135)

* Replaces `must` with `should` as that `must` does not work on objects that don't have PAF

* fix for tests