### PR TITLE
Update application.conf

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -147,7 +147,7 @@ addressIndex {
       }
       disMaxTieBreaker=0.0
       disMaxTieBreaker=${?ONS_AI_API_QUERY_TIE_BREAKER_BOOST}
-      allBoost=0.2
+      allBoost=0.1
       allBoost=${?ONS_AI_API_QUERY_ALL_BOOST}
       defaultBoost=1.0
       defaultBoost=${?ONS_AI_API_QUERY_DEFAULT_BOOST}


### PR DESCRIPTION
Changing the boost of the fallback from 0.2 to 0.1 to reduce the importance. This helps to reduce the number of false positives on EdgeCases.