### PR TITLE
Update Tokens.scala

### DIFF
--- a/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
+++ b/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
@@ -72,8 +72,9 @@ object Tokens extends CrfTokenable {
 
     val tokens = inputWithoutCounties
       .replaceAll("(\\d+) *- *(\\d+)", "$1-$2")
+      .replaceAll("(\\d+[A-Z]) *- *(\\d+[A-Z])", "$1-$2")
       .replaceAll("(\\d+)/(\\d+)", "$1-$2")
-      .replace(" TO ", "-")
+      .replace("(\\d+) *TO *(\\d+)", "$1-$2")
       .replace(" IN ", " ")
       .replace(" CO ", " ")
       .replace(" - ", " ")

--- a/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
+++ b/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
@@ -74,7 +74,7 @@ object Tokens extends CrfTokenable {
       .replaceAll("(\\d+) *- *(\\d+)", "$1-$2")
       .replaceAll("(\\d+[A-Z]) *- *(\\d+[A-Z])", "$1-$2")
       .replaceAll("(\\d+)/(\\d+)", "$1-$2")
-      .replace("(\\d+) *TO *(\\d+)", "$1-$2")
+      .replaceAll("(\\d+) *TO *(\\d+)", "$1-$2")
       .replace(" IN ", " ")
       .replace(" CO ", " ")
       .replace(" - ", " ")

--- a/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/TokensTest.scala
+++ b/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/TokensTest.scala
@@ -40,7 +40,7 @@ class TokensTest extends FlatSpec with Matchers {
   }
 
   it should "produce tokens, replacing `to` with hyphen" in {
-    val input = "1 to 2 3 to 4"
+    val input = "1 TO 2 3 TO 4"
     val expected = Seq("1-2", "3-4")
     val actual = Tokens(input)
     actual shouldBe expected


### PR DESCRIPTION
Added white space removal for addresses with both number and suffix range. This could also be combined with the operation on line 74 if the suffixes were made optional. Modified the "TO" replacement with hyphen to require that it is proceeded and followed by digits.