### PR TITLE
Update application.conf

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -145,7 +145,7 @@ addressIndex {
         pafWelshDoubleDependentLocalityBoost=0.3
         pafWelshDoubleDependentLocalityBoost=${?ONS_AI_API_QUERY_LOCALITY_PAF_WELSH_DOUBLE_DEPENDENT_LOCALITY_BOOST}
       }
-      disMaxTieBreaker=0.0
+      disMaxTieBreaker=0.5
       disMaxTieBreaker=${?ONS_AI_API_QUERY_TIE_BREAKER_BOOST}
       allBoost=0.1
       allBoost=${?ONS_AI_API_QUERY_ALL_BOOST}


### PR DESCRIPTION
Changing tie breaker default from 0 to 0.5. This helps with addresses with number and suffix ranges. The SAO test dataset went from 97 to 13 false positives.