### PR TITLE
Removes a feature that transformed a letter from BuildingName into SubBuildingName (as it does not work)

### DIFF
--- a/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
+++ b/parsers/src/main/scala/uk/gov/ons/addressIndex/parsers/Tokens.scala
@@ -71,8 +71,7 @@ object Tokens extends CrfTokenable {
     val inputWithoutCounties = removeCounties(upperInput)
 
     val tokens = inputWithoutCounties
-      .replaceAll("(\\d+) *- *(\\d+)", "$1-$2")
-      .replaceAll("(\\d+[A-Z]) *- *(\\d+[A-Z])", "$1-$2")
+      .replaceAll("(\\d+[A-Z]?) *- *(\\d+[A-Z]?)", "$1-$2")
       .replaceAll("(\\d+)/(\\d+)", "$1-$2")
       .replaceAll("(\\d+) *TO *(\\d+)", "$1-$2")
       .replace(" IN ", " ")
@@ -119,9 +118,8 @@ object Tokens extends CrfTokenable {
     val boroughTreatedTokens = postTokenizeTreatmentBorough(postcodeTreatedTokens)
     val buildingNumberTreatedTokens = postTokenizeTreatmentBuildingNumber(boroughTreatedTokens)
     val buildingNameTreatedTokens = postTokenizeTreatmentBuildingName(buildingNumberTreatedTokens)
-    val subBuildingNameTreatedTokens = postTokenizeTreatmentSubBuildingName(buildingNameTreatedTokens)
 
-    subBuildingNameTreatedTokens
+    buildingNameTreatedTokens
   }
 
   /**
@@ -330,24 +328,6 @@ object Tokens extends CrfTokenable {
         BuildingNameSplit(startNumber = Try(number.toShort.toString).toOption)
 
       case _ => BuildingNameSplit()
-    }
-  }
-
-  /**
-    * Some flat names are written into the building name
-    * Example: "50A" buildingName may actually mean "50" building number and "FLAT A"
-    * as subBuildingName
-    * @param tokens current tokens
-    * @return tokens with updated subBuildingName if needed
-    */
-  def postTokenizeTreatmentSubBuildingName(tokens: Map[String, String]): Map[String, String] = {
-    val paoStartSuffixToken = tokens.get(paoStartSuffix)
-    val subBuildingNameToken = tokens.get(subBuildingName)
-    val subBuildingNamePrefix = "FLAT "
-
-    (paoStartSuffixToken, subBuildingNameToken) match {
-      case (Some(flatName), None) => tokens + (subBuildingName -> s"$subBuildingNamePrefix$flatName")
-      case _ => tokens
     }
   }
 

--- a/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/TokensTest.scala
+++ b/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/TokensTest.scala
@@ -33,8 +33,15 @@ class TokensTest extends FlatSpec with Matchers {
   }
 
   it should "produce tokens, removing spaces around hyphen" in {
-    val input = "1 -2 3 - 4 5- 6 a - b 7   - 8 9 -    1"
+    val input = "1 -2 3 - 4 5- 6 A - B 7   - 8 9 -    1"
     val expected = Seq("1-2", "3-4", "5-6", "A", "B", "7-8", "9-1")
+    val actual = Tokens(input)
+    actual shouldBe expected
+  }
+
+  it should "produce tokens, removing spaces around hyphen (numbers with letters)" in {
+    val input = "1A -2B 3A - 4 5- 6B 9 - 1"
+    val expected = Seq("1A-2B", "3A-4", "5-6B", "9-1")
     val actual = Tokens(input)
     actual shouldBe expected
   }

--- a/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/postTokenizeTreatmentTest.scala
+++ b/parsers/src/test/scala/uk/gov/ons/addressIndex/parsers/postTokenizeTreatmentTest.scala
@@ -419,49 +419,4 @@ class postTokenizeTreatmentTest extends FlatSpec with Matchers {
     actual shouldBe expected
   }
 
-  it should "add FLAT name to the subBuildingName if paoStartSuffix is set" in {
-    // Given
-    val input = List(
-      CrfTokenResult(
-        value = "A",
-        label = Tokens.paoStartSuffix
-      )
-    )
-
-    val expected = Map(
-      Tokens.paoStartSuffix -> "A",
-      Tokens.subBuildingName -> "FLAT A"
-    )
-
-    // When
-    val actual = Tokens.postTokenizeTreatment(input)
-
-    // Then
-    actual shouldBe expected
-  }
-
-  it should "NOT add FLAT name to the subBuildingName if subBuildingName is already set" in {
-    // Given
-    val input = List(
-      CrfTokenResult(
-        value = "A",
-        label = Tokens.paoStartSuffix
-      ),
-      CrfTokenResult(
-        value = "B",
-        label = Tokens.subBuildingName
-      )
-    )
-
-    val expected = Map(
-      Tokens.paoStartSuffix -> "A",
-      Tokens.subBuildingName -> "B"
-    )
-
-    // When
-    val actual = Tokens.postTokenizeTreatment(input)
-
-    // Then
-    actual shouldBe expected
-  }
 }


### PR DESCRIPTION
Also fixes a small bug with hyphen treatment where 3A - 3 was transformed into "3A 3" instead of "3A-3"