### PR TITLE
change splunk logs to info

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
@@ -26,7 +26,7 @@ object Splunk {
     score: String = "",
     uuid: String = ""
   ): Unit = {
-    logger.trace(
+    logger.info(
       s" IP=$IP url=$url millis=${System.currentTimeMillis()} response_time_millis=$responseTimeMillis is_uprn=$isUprn is_input=$isInput is_bulk=$isBulk " +
         s"uprn=$uprn input=$input offset=$offset limit=$limit bulk_size=$bulkSize batch_size=$batchSize " +
         s"bad_request_message=$badRequestMessage is_not_found=$isNotFound formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +


### PR DESCRIPTION
As we are now going ahead with Splunk, we need the Splunk logging threshold changed from TRACE to INFO. It looks like for Cloud Foundry it has go to STDOUT - otherwise it would have been tidier to write the logs we want in Splunk to a separate physical file.