### PR TITLE
Hopper Score: Add missing tests and tidy Tokens file getters

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
@@ -869,8 +869,7 @@ object HopperScoreHelper  {
       saoStartSuffix,
       saoEndSuffix,
       saoStartNumber,
-      saoEndNumber,
-      pafBuildingNumber)
+      saoEndNumber)
 
     val subBuildingNumberParam = subBuildingNumberPafScore.min(subBuildingNumberNagScore)
 
@@ -1001,8 +1000,7 @@ object HopperScoreHelper  {
     saoStartSuffix: String,
     saoEndSuffix: String,
     saoStartNumber: String,
-    saoEndNumber: String,
-    pafBuildingNumber: String) : Int = {
+    saoEndNumber: String) : Int = {
 
     val tokenBuildingLowNum = getRangeBottom(subBuildingName)
     val tokenBuildingHighNum = tokenBuildingLowNum.max(getRangeTop(subBuildingName))

--- a/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
@@ -596,8 +596,7 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
     val expected = 1
 
     // When
-    val actual = HopperScoreHelper.
-      calculateTownLocalityPafScore (
+    val actual = HopperScoreHelper.calculateTownLocalityPafScore (
       townName,
       locality,
       pafPostTown,
@@ -607,6 +606,178 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
       pafDoubleDependentLocality,
       pafWelshDoubleDependentLocality,
       streetName)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the town locality nag score for an address " in {
+    // Given
+    val townName = "PARK GATE"
+    val locality = "SOUTHAMPTON"
+    val nagTownName = "PORKY GATER"
+    val streetName = ""
+    val nagLocality = "SOTON"
+    val expected = 6
+
+    // When
+    val actual = HopperScoreHelper.calculateTownLocalityNagScore (
+        townName,
+        nagTownName,
+        locality,
+        nagLocality,
+        streetName)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the postcode paf score for an address " in {
+    // Given
+    val postcode = "PO15 5RR"
+    val pafPostcode = "PO15 5RR"
+    val postcodeOut = "PO15"
+    val postcodeWithInvertedIncode = "PO15 5RR"
+    val postcodeSector = "PO15 5"
+    val postcodeArea = "PO"
+    val expected = 1
+
+    // When
+    val actual = HopperScoreHelper.calculatePostcodePafScore (
+      postcode,
+      pafPostcode,
+      postcodeOut,
+      postcodeWithInvertedIncode,
+      postcodeSector,
+      postcodeArea)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the postcode nag score for an address " in {
+    // Given
+    val postcode = "PO15 5RS"
+    val nagPostcode = "PO15 5SR"
+    val postcodeOut = "PO15"
+    val postcodeWithInvertedIncode = "PO15 5SR"
+    val postcodeSector = "PO15 5"
+    val postcodeArea = "PO"
+    val expected = 3
+
+    // When
+    val actual = HopperScoreHelper.calculatePostcodeNagScore (
+      postcode: String,
+      nagPostcode: String,
+      postcodeOut: String,
+      postcodeWithInvertedIncode: String,
+      postcodeSector: String,
+      postcodeArea: String)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the orgainisation name nag score for an address " in {
+    // Given
+    val organisationName = "BONGO WONGO"
+    val nagPaoText = "WINGO BINGO"
+    val nagSaoText = "GAMBLING DEN 2"
+    val nagOrganisationName = "WINGO BINGO"
+    val expected = 1
+
+    // When
+    val actual = HopperScoreHelper.calculateOrganisationNameNagScore(
+      organisationName,
+      nagPaoText,
+      nagSaoText,
+      nagOrganisationName)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the sub building name paf score for an address " in {
+    // Given
+    val subBuildingName = "ANNEX THREE"
+    val pafSubBuildingName = "THE ANNEX"
+    val expected = 3
+
+    // When
+    val actual = HopperScoreHelper.calculateSubBuildingNamePafScore(
+      subBuildingName,
+      pafSubBuildingName)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the sub building name nag score for an address " in {
+    // Given
+    val subBuildingName = "ANNEX THREE"
+    val nagSaoText = "ANNEX 3"
+    val expected = 6
+
+    // When
+    val actual = HopperScoreHelper.calculateSubBuildingNameNagScore(
+      subBuildingName,
+      nagSaoText)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the sub building number paf score for an address " in {
+    // Given
+    val subBuildingName = "UNIT 3A"
+    val pafSubBuildingName = "UNIT 3A"
+    val pafBuildingName = "JENGA TOWERS"
+    val pafBuildingNumber ="42"
+    val saoStartSuffix = "A"
+    val saoEndSuffix = ""
+    val saoStartNumber = "42"
+    val saoEndNumber = ""
+    val expected = 1
+
+    // When
+    val actual = HopperScoreHelper.calculateSubBuildingNumberPafScore (
+      subBuildingName,
+      pafSubBuildingName,
+      pafBuildingName,
+      saoStartSuffix,
+      saoEndSuffix,
+      saoStartNumber,
+      saoEndNumber,
+      pafBuildingNumber)
+
+    // Then
+    actual shouldBe expected
+  }
+
+  it should "calculate the sub building number nag score for an address " in {
+    // Given
+    val subBuildingName = "UNIT 3A"
+    val nagSaoStartNumber = "3"
+    val nagSaoEndNumber = ""
+    val nagSaoStartSuffix = "A"
+    val nagSaoEndSuffix = ""
+    val saoStartSuffix = "A"
+    val saoEndSuffix = ""
+    val saoStartNumber = "42"
+    val saoEndNumber = ""
+    val expected = 1
+
+    // When
+    val actual = HopperScoreHelper.calculateSubBuildingNumberNagScore (
+      subBuildingName,
+      nagSaoStartNumber,
+      nagSaoEndNumber,
+      nagSaoStartSuffix,
+      nagSaoEndSuffix,
+      saoStartSuffix,
+      saoEndSuffix,
+      saoStartNumber,
+      saoEndNumber)
 
     // Then
     actual shouldBe expected


### PR DESCRIPTION
This PR is for the outstanding tasks from PR 177 (which were deferred to not hold up testing). All 37 methods of HopperScoreHelper now have unit tests, and the Tokens code has been tidied up so that fileToList and fileToMap accept pathname parameters (defaulted) and the code to get the  buffered source is not duplicated. Note that the custodian codes will benefit from this change when they are moved to an external file.