### PR TITLE
Allows the user of the bulk request to set config parameters manually

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -25,7 +25,7 @@ case class AddressIndexSearchRequest(
   *               of env vars or a new pull request if you want to
   *               do more permanent configuration values)
   */
-case class BulkBody(addresses: Seq[BulkQuery], config: Option[QueryParamsConfig])
+case class BulkBody(addresses: Seq[BulkQuery], config: Option[QueryParamsConfig] = None)
 
 object BulkBody {
   implicit lazy val fmt: Format[BulkBody] = Json.format[BulkBody]

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -3,9 +3,7 @@ package uk.gov.ons.addressIndex.model
 import java.util.UUID
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.ons.addressIndex.model.db.BulkAddress
-import uk.gov.ons.addressIndex.model.server.response.AddressResponseAddress
-import uk.gov.ons.addressIndex.parsers.Tokens
+import uk.gov.ons.addressIndex.model.config.QueryParamsConfig
 
 case class AddressIndexUPRNRequest(
   uprn: BigInt,
@@ -20,13 +18,29 @@ case class AddressIndexSearchRequest(
 )
 
 
-//mini model for input post body
-case class BulkBody(addresses: Seq[BulkQuery])
+/**
+  * The body of the request that is sent to the bulk api endpoint
+  * @param addresses collection of addresses that will be queried
+  * @param config optional configuration overwrite (prefer the use
+  *               of env vars or a new pull request if you want to
+  *               do more permanent configuration values)
+  */
+case class BulkBody(addresses: Seq[BulkQuery], config: Option[QueryParamsConfig])
+
 object BulkBody {
   implicit lazy val fmt: Format[BulkBody] = Json.format[BulkBody]
 }
 
+/**
+  * An element in the collection of addresses in the bulk request
+  * @param id the id of the address that will be returned with the
+  *           result (used to join source table with results).
+  *           This is not UPRN. Basic example is just line number.
+  * @param address the input that will be queried to find corresponding
+  *                addresses
+  */
 case class BulkQuery(id: String, address: String)
+
 object BulkQuery {
   implicit lazy val fmt: Format[BulkQuery] = Json.format[BulkQuery]
 }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -1,5 +1,7 @@
 package uk.gov.ons.addressIndex.model.config
 
+import play.api.libs.json.{Format, Json}
+
 case class AddressIndexConfig(
   parserLibPath: String,
   pathToResources: String,
@@ -38,6 +40,11 @@ case class QueryParamsConfig(
   fallbackMinimumShouldMatch: String
 )
 
+// This is required for the bulk request as Data Scientists want to provide query params dynamically
+object QueryParamsConfig {
+  implicit val queryParamsConfigFormat: Format[QueryParamsConfig] = Json.format[QueryParamsConfig]
+}
+
 case class ShieldConfig(
   ssl: Boolean,
   user: String,
@@ -58,6 +65,10 @@ case class SubBuildingNameConfig(
   lpiSaoTextBoost: Float
  )
 
+object SubBuildingNameConfig {
+  implicit val subBuildingNameConfigFormat: Format[SubBuildingNameConfig] = Json.format[SubBuildingNameConfig]
+}
+
 case class BuildingNameConfig(
   lpiPaoStartNumberBoost: Float,
   lpiPaoStartSuffixBoost: Float,
@@ -67,10 +78,18 @@ case class BuildingNameConfig(
   lpiPaoTextBoost: Float
 )
 
+object BuildingNameConfig {
+  implicit val buildingNameConfigFormat: Format[BuildingNameConfig] = Json.format[BuildingNameConfig]
+}
+
 case class BuildingNumberConfig(
   pafBuildingNumberBoost: Float,
   lpiPaoStartNumberBoost: Float
 )
+
+object BuildingNumberConfig {
+  implicit val buildingNumberConfigFormat: Format[BuildingNumberConfig] = Json.format[BuildingNumberConfig]
+}
 
 case class StreetNameConfig(
   pafThoroughfareBoost: Float,
@@ -79,6 +98,10 @@ case class StreetNameConfig(
   pafWelshDependentThoroughfareBoost: Float,
   lpiStreetDescriptorBoost: Float
 )
+
+object StreetNameConfig {
+  implicit val streetNameConfigFormat: Format[StreetNameConfig] = Json.format[StreetNameConfig]
+}
 
 case class TownNameConfig(
   pafPostTownBoost: Float,
@@ -91,6 +114,10 @@ case class TownNameConfig(
   pafWelshDoubleDependentLocalityBoost: Float
 )
 
+object TownNameConfig {
+  implicit val townNameConfigFormat: Format[TownNameConfig] = Json.format[TownNameConfig]
+}
+
 case class PostcodeConfig(
   pafPostcodeBoost: Float,
   lpiPostcodeLocatorBoost: Float,
@@ -98,6 +125,10 @@ case class PostcodeConfig(
   postcodeOutBoost: Float,
   postcodeInBoost: Float
 )
+
+object PostcodeConfig {
+  implicit val postcodeConfigFormat: Format[PostcodeConfig] = Json.format[PostcodeConfig]
+}
 
 case class OrganisationNameConfig(
   pafOrganisationNameBoost: Float,
@@ -107,10 +138,18 @@ case class OrganisationNameConfig(
   lpiSaoTextBoost: Float
 )
 
+object OrganisationNameConfig {
+  implicit val organisationNameConfigFormat: Format[OrganisationNameConfig] = Json.format[OrganisationNameConfig]
+}
+
 case class DepartmentNameConfig(
   pafDepartmentNameBoost: Float,
   lpiLegalNameBoost: Float
 )
+
+object DepartmentNameConfig {
+  implicit val departmentConfigFormat: Format[DepartmentNameConfig] = Json.format[DepartmentNameConfig]
+}
 
 case class LocalityConfig(
   pafPostTownBoost: Float,
@@ -122,6 +161,10 @@ case class LocalityConfig(
   pafDoubleDependentLocalityBoost: Float,
   pafWelshDoubleDependentLocalityBoost: Float
 )
+
+object LocalityConfig {
+  implicit val localityConfigFormat: Format[LocalityConfig] = Json.format[LocalityConfig]
+}
 
 case class BulkConfig(
   batch: BatchConfig,

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -7,9 +7,9 @@ import com.google.inject.ImplementedBy
 import com.sksamuel.elastic4s.ElasticDsl.{must, should, _}
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.analyzers.CustomAnalyzer
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse
 import org.elasticsearch.search.sort.SortOrder
 import play.api.Logger
+import uk.gov.ons.addressIndex.model.config.QueryParamsConfig
 import uk.gov.ons.addressIndex.model.db.{BulkAddress, BulkAddressRequestData}
 import uk.gov.ons.addressIndex.model.db.index._
 import uk.gov.ons.addressIndex.parsers.Tokens
@@ -40,7 +40,7 @@ trait ElasticsearchRepository {
     * @param tokens address tokens
     * @return Future with found addresses and the maximum score
     */
-  def queryAddresses(start: Int, limit: Int, tokens: Map[String, String]): Future[HybridAddresses]
+  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None): Future[HybridAddresses]
 
   /**
     * Generates request to get address from ES by UPRN
@@ -49,7 +49,7 @@ trait ElasticsearchRepository {
     * @param tokens tokens for the ES query
     * @return Search definition containing query to the ES
     */
-  def generateQueryAddressRequest(tokens: Map[String, String]): SearchDefinition
+  def generateQueryAddressRequest(tokens: Map[String, String], queryParamsConfig: Option[QueryParamsConfig] = None): SearchDefinition
 
   /**
     * Query ES using MultiSearch endpoint
@@ -59,7 +59,7 @@ trait ElasticsearchRepository {
     * @return a stream of `Either`, `Right` will contain resulting bulk address,
     *         `Left` will contain request data that is to be re-send
     */
-  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int): Future[Stream[Either[BulkAddressRequestData, Seq[BulkAddress]]]]
+  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None): Future[Stream[Either[BulkAddressRequestData, Seq[BulkAddress]]]]
 }
 
 @Singleton
@@ -70,7 +70,6 @@ class AddressIndexRepository @Inject()(
 
   private val esConf = conf.config.elasticSearch
   private val hybridIndex = esConf.indexes.hybridIndex + "/" + esConf.indexes.hybridMapping
-  private val queryParams = conf.config.elasticSearch.queryParams
 
   val client: ElasticClient = elasticClientProvider.client
   val logger = Logger("AddressIndexRepository")
@@ -101,7 +100,7 @@ class AddressIndexRepository @Inject()(
     termQuery("uprn", uprn)
   }
 
-  def queryAddresses(start: Int, limit: Int, tokens: Map[String, String]): Future[HybridAddresses] = {
+  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None): Future[HybridAddresses] = {
 
     val request = generateQueryAddressRequest(tokens).start(start).limit(limit)
 
@@ -110,8 +109,9 @@ class AddressIndexRepository @Inject()(
     client.execute(request).map(HybridAddresses.fromRichSearchResponse)
   }
 
-  def generateQueryAddressRequest(tokens: Map[String, String]): SearchDefinition = {
+  def generateQueryAddressRequest(tokens: Map[String, String], queryParamsConfig: Option[QueryParamsConfig] = None): SearchDefinition = {
 
+    val queryParams = queryParamsConfig.getOrElse(conf.config.elasticSearch.queryParams)
     val defaultFuzziness = "1"
 
     val saoQuery = Seq(
@@ -459,11 +459,11 @@ class AddressIndexRepository @Inject()(
 
   }
 
-  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int): Future[Stream[Either[BulkAddressRequestData, Seq[BulkAddress]]]] = {
+  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None): Future[Stream[Either[BulkAddressRequestData, Seq[BulkAddress]]]] = {
 
     val addressRequests = requestsData.map { requestData =>
       val bulkAddressRequest: Future[Seq[BulkAddress]] =
-        queryAddresses(0, limit, requestData.tokens).map { case HybridAddresses(hybridAddresses, _, _) =>
+        queryAddresses(requestData.tokens, 0, limit).map { case HybridAddresses(hybridAddresses, _, _) =>
 
           // If we didn't find any results for an input, we still need to return
           // something that will indicate an empty result

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -481,7 +481,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
       val expected = expectedHybrid
 
       // When
-      val HybridAddresses(results, maxScore, total) = repository.queryAddresses(0, 10, tokens).await
+      val HybridAddresses(results, maxScore, total) = repository.queryAddresses(tokens, 0, 10).await
 
       // Then
       results.length should be > 0 // it MAY return more than 1 addresses, but the top one should remain the same
@@ -502,7 +502,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Elas
       )
 
       // When
-      val HybridAddresses(results, maxScore, total) = repository.queryAddresses(0, 10, tokens).await
+      val HybridAddresses(results, maxScore, total) = repository.queryAddresses(tokens, 0, 10).await
 
       // Then
       results.length shouldBe 0


### PR DESCRIPTION
Example of a request to `/bulk` (with current config parameters in application.conf):
```
{
    "addresses": [{
        "id": "1",
        "address": "132 SOME STREET, EXETER, E10 6GY"
    },{
        "id": "2",
        "address": "132 SOME STREET, EXETER, E10 6GY"
    }],
    "config":{
        "subBuildingName": {
          "lpiSaoStartNumberBoost": 1.0,
          "lpiSaoStartSuffixBoost": 1.0,
          "lpiSaoEndNumberBoost": 1.0,
          "lpiSaoEndSuffixBoost": 1.0,
          "pafSubBuildingNameBoost": 1.5,
          "lpiSaoTextBoost": 1.5
        },
        "buildingName": {
          "lpiPaoStartNumberBoost": 2.5,
          "lpiPaoStartSuffixBoost": 3.5,
          "lpiPaoEndNumberBoost": 2.5,
          "lpiPaoEndSuffixBoost": 2.5,
          "pafBuildingNameBoost": 2.5,
          "lpiPaoTextBoost": 2.5
        },
        "buildingNumber": {
          "pafBuildingNumberBoost": 2.0,
          "lpiPaoStartNumberBoost": 2.0
        },
        "streetName": {
          "pafThoroughfareBoost": 2.0,
          "pafWelshThoroughfareBoost": 2.0,
          "pafDependentThoroughfareBoost": 0.5,
          "pafWelshDependentThoroughfareBoost": 0.5,
          "lpiStreetDescriptorBoost": 2.0
        },
        "townName": {
          "pafPostTownBoost": 1.0,
          "pafWelshPostTownBoost": 1.0,
          "lpiTownNameBoost": 1.0,
          "pafDependentLocalityBoost": 0.5,
          "pafWelshDependentLocalityBoost": 0.5,
          "lpiLocalityBoost": 0.5,
          "pafDoubleDependentLocalityBoost": 0.2,
          "pafWelshDoubleDependentLocalityBoost": 0.2
        },
        "postcode": {
          "pafPostcodeBoost": 1.0,
          "lpiPostcodeLocatorBoost": 1.0,
          "postcodeInOutBoost": 0.8,
          "postcodeOutBoost": 0.8,
          "postcodeInBoost": 0.3
        },
        "organisationName": {
          "pafOrganisationNameBoost": 1.0,
          "lpiOrganisationBoost": 1.0,
          "lpiPaoTextBoost": 1.0,
          "lpiLegalNameBoost": 1.0,
          "lpiSaoTextBoost": 0.5
        },
        "departmentName": {
          "pafDepartmentNameBoost": 1.0,
          "lpiLegalNameBoost": 0.5
        },
        "locality": {
          "pafPostTownBoost": 0.2,
          "pafWelshPostTownBoost": 0.2,
          "lpiTownNameBoost": 0.2,
          "pafDependentLocalityBoost": 0.5,
          "pafWelshDependentLocalityBoost": 0.5,
          "lpiLocalityBoost": 0.5,
          "pafDoubleDependentLocalityBoost": 0.3,
          "pafWelshDoubleDependentLocalityBoost": 0.3
        },
        "excludingDisMaxTieBreaker": 0.0,
        "includingDisMaxTieBreaker": 0.5,
        "fallbackQueryBoost": 0.1,
        "defaultBoost": 1.0,
        "mainMinimumShouldMatch": "-35%",
        "fallbackMinimumShouldMatch": "-35%"
      }
}
```