### PR TITLE
Adds bulk entrypoint where we can provide tokens instead of input

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -45,3 +45,22 @@ object BulkQuery {
   implicit lazy val fmt: Format[BulkQuery] = Json.format[BulkQuery]
 }
 
+/**
+  * Specific request format where we directly provide tokens instead of the input
+  * @param addresses collection of addresses (tokens instead of input) to be queried
+  * @param config optional configuration that will overwrite current one
+  */
+case class BulkBodyDebug(addresses: Seq[BulkQueryDebug], config: Option[QueryParamsConfig] = None)
+
+object BulkBodyDebug {
+  implicit lazy val bulkQueryDebugFormat: Format[BulkQueryDebug] = Json.format[BulkQueryDebug]
+  implicit lazy val bulkBodyDebugFormat: Format[BulkBodyDebug] = Json.format[BulkBodyDebug]
+}
+
+/**
+  * An element in the collection of a bulk request, this time we have tokens
+  * instead of text input
+  * @param id the id of the address
+  * @param tokens tokens to be queried (thus this bypasses the parser step)
+  */
+case class BulkQueryDebug(id: String, tokens: Map[String, String])

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -21,3 +21,5 @@ GET     /version            uk.gov.ons.addressIndex.server.controllers.VersionCo
 POST    /bulk               uk.gov.ons.addressIndex.server.controllers.AddressController.bulk
 
 POST    /bulk-full          uk.gov.ons.addressIndex.server.controllers.AddressController.bulkFull
+
+POST    /bulk-debug          uk.gov.ons.addressIndex.server.controllers.AddressController.bulkDebug


### PR DESCRIPTION
Example of request:

```
{  
   "addresses":[  
      {  
         "id":"1",
         "tokens":{  
            "PostcodeOut":"EX4",
            "BuildingNumber":"1",
            "PostcodeIn":"4SW",
            "Postcode":"EX4 4SW",
            "PaoStartNumber":"1"
         }
      },
      {  
         "id":"2",
         "tokens":{  
            "PostcodeOut":"EX4",
            "BuildingNumber":"1",
            "PostcodeIn":"4SW",
            "Postcode":"EX4 4SW",
            "PaoStartNumber":"1"
         }
      }
   ],
   "config":{  
      "subBuildingName":{  
         "lpiSaoStartNumberBoost":1.0,
         "lpiSaoStartSuffixBoost":1.0,
         "lpiSaoEndNumberBoost":1.0,
         "lpiSaoEndSuffixBoost":1.0,
         "pafSubBuildingNameBoost":1.5,
         "lpiSaoTextBoost":1.5
      },
      "buildingName":{  
         "lpiPaoStartNumberBoost":2.5,
         "lpiPaoStartSuffixBoost":3.5,
         "lpiPaoEndNumberBoost":2.5,
         "lpiPaoEndSuffixBoost":2.5,
         "pafBuildingNameBoost":2.5,
         "lpiPaoTextBoost":2.5
      },
      "buildingNumber":{  
         "pafBuildingNumberBoost":2.0,
         "lpiPaoStartNumberBoost":2.0
      },
      "streetName":{  
         "pafThoroughfareBoost":2.0,
         "pafWelshThoroughfareBoost":2.0,
         "pafDependentThoroughfareBoost":0.5,
         "pafWelshDependentThoroughfareBoost":0.5,
         "lpiStreetDescriptorBoost":2.0
      },
      "townName":{  
         "pafPostTownBoost":1.0,
         "pafWelshPostTownBoost":1.0,
         "lpiTownNameBoost":1.0,
         "pafDependentLocalityBoost":0.5,
         "pafWelshDependentLocalityBoost":0.5,
         "lpiLocalityBoost":0.5,
         "pafDoubleDependentLocalityBoost":0.2,
         "pafWelshDoubleDependentLocalityBoost":0.2
      },
      "postcode":{  
         "pafPostcodeBoost":1.0,
         "lpiPostcodeLocatorBoost":1.0,
         "postcodeInOutBoost":0.8,
         "postcodeOutBoost":0.8,
         "postcodeInBoost":0.3
      },
      "organisationName":{  
         "pafOrganisationNameBoost":1.0,
         "lpiOrganisationBoost":1.0,
         "lpiPaoTextBoost":1.0,
         "lpiLegalNameBoost":1.0,
         "lpiSaoTextBoost":0.5
      },
      "departmentName":{  
         "pafDepartmentNameBoost":1.0,
         "lpiLegalNameBoost":0.5
      },
      "locality":{  
         "pafPostTownBoost":0.2,
         "pafWelshPostTownBoost":0.2,
         "lpiTownNameBoost":0.2,
         "pafDependentLocalityBoost":0.5,
         "pafWelshDependentLocalityBoost":0.5,
         "lpiLocalityBoost":0.5,
         "pafDoubleDependentLocalityBoost":0.3,
         "pafWelshDoubleDependentLocalityBoost":0.3
      },
      "excludingDisMaxTieBreaker":0.0,
      "includingDisMaxTieBreaker":0.5,
      "fallbackQueryBoost":0.1,
      "defaultBoost":1.0,
      "mainMinimumShouldMatch":"-35%",
      "fallbackMinimumShouldMatch":"-35%"
   }
}
```