### PR TITLE
Log network userid of API requestor to Splunk (JIRA 355)

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ApplicationHomeController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ApplicationHomeController.scala
@@ -103,7 +103,7 @@ class ApplicationHomeController @Inject()(conf: DemouiConfigModule, version: Dem
 
         // Any response other than a 200 is assumed to be an authentication failure (e.g. 401)
         if (result.status != OK) {
-          val key = (result.json \ "key").as[String]
+          val key = userName + "_" + (result.json \ "key").as[String]
           Redirect(new Call("GET", req.session.get("referer").getOrElse(default = "/home"))).withSession("api-key" -> key)
         } else Ok(uk.gov.ons.addressIndex.demoui.views.html.login("Authentication failed",version))
 
@@ -111,7 +111,7 @@ class ApplicationHomeController @Inject()(conf: DemouiConfigModule, version: Dem
         {
           val fakeResponse = GatewaySimulator.getApiKey(userName,password)
           if (fakeResponse.errorCode == "") {
-            val key = fakeResponse.key
+            val key = userName + "_" + fakeResponse.key
             Redirect(new Call("GET", req.session.get("referer").getOrElse(default = "/home"))).withSession("api-key" -> key)
           } else Ok(uk.gov.ons.addressIndex.demoui.views.html.login("Authentication failed",version))
         }

--- a/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
@@ -24,13 +24,14 @@ object Splunk {
     formattedOutput: String = "",
     numOfResults: String = "",
     score: String = "",
-    uuid: String = ""
+    uuid: String = "",
+    networkid: String = ""
   ): Unit = {
     logger.info(
       s" IP=$IP url=$url millis=${System.currentTimeMillis()} response_time_millis=$responseTimeMillis is_uprn=$isUprn is_input=$isInput is_bulk=$isBulk " +
         s"uprn=$uprn input=$input offset=$offset limit=$limit bulk_size=$bulkSize batch_size=$batchSize " +
         s"bad_request_message=$badRequestMessage is_not_found=$isNotFound formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +
-        s"numOfResults=$numOfResults score=$score uuid=$uuid"
+        s"numOfResults=$numOfResults score=$score uuid=$uuid networkid=$networkid"
     )
   }
 

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -17,10 +17,10 @@ addressIndex {
   parserLibPath = ${?ONS_AI_LIBRARY_PATH}
   elasticSearch {
     local = false
-    cluster = "e8eb8ad51fb4d8a75b99d7cf844f7c19"
+    cluster = "5a4b483efe6d6875f4607a360ed6b824"
     cluster = ${?ONS_AI_API_ES_CLUSTER_NAME}
     // if you are using a remote server over SSL, try to use port 9343
-    uri = "elasticsearch://e8eb8ad51fb4d8a75b99d7cf844f7c19.eu-west-1.aws.found.io:9343"
+    uri = "elasticsearch://5a4b483efe6d6875f4607a360ed6b824.eu-west-1.aws.found.io:9343"
     uri = ${?ONS_AI_API_ES_URI}
     shield {
       user = "admin"


### PR DESCRIPTION
UI calls the login policy on the gateway, then joins the userid and and underscore to the returned apikey.

Gateway policies for API calls split the key to remove the userid before validating the key.

API AddressController gets the api key from the authorization header and splits it to get the userid which is added to the Splunk log.