### PR TITLE
Disable splunk logging

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -449,7 +449,8 @@ class AddressController @Inject()(
     val keyRequired = conf.config.apiKeyRequired
     if (keyRequired) {
       val masterKey = conf.config.masterKey
-      apiKey match {
+      val apiKeyTest = apiKey.drop(apiKey.indexOf("_")+1)
+      apiKeyTest match {
         case key if key == missing => missing
         case key if key == masterKey => valid
         case _ => invalid

--- a/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
@@ -27,7 +27,7 @@ object Splunk {
     uuid: String = "",
     networkid: String = ""
   ): Unit = {
-    logger.info(
+    logger.trace(
       s" IP=$IP url=$url millis=${System.currentTimeMillis()} response_time_millis=$responseTimeMillis is_uprn=$isUprn is_input=$isInput is_bulk=$isBulk " +
         s"uprn=$uprn input=$input offset=$offset limit=$limit bulk_size=$bulkSize batch_size=$batchSize " +
         s"bad_request_message=$badRequestMessage is_not_found=$isNotFound formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +


### PR DESCRIPTION
As it now looks like ticket 445 won't be done before we go to master, I have turned off the logging. The security one may get done so I have made a small needed tweak to the API key in anticipation of this being enabled soon.