### PR TITLE
Enable splunk logging

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/Splunk.scala
@@ -27,7 +27,7 @@ object Splunk {
     uuid: String = "",
     networkid: String = ""
   ): Unit = {
-    logger.trace(
+    logger.info(
       s" IP=$IP url=$url millis=${System.currentTimeMillis()} response_time_millis=$responseTimeMillis is_uprn=$isUprn is_input=$isInput is_bulk=$isBulk " +
         s"uprn=$uprn input=$input offset=$offset limit=$limit bulk_size=$bulkSize batch_size=$batchSize " +
         s"bad_request_message=$badRequestMessage is_not_found=$isNotFound formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +


### PR DESCRIPTION
The CloudFoundry syslog drain is now working. We don't have an external config way of changing  logging settings currently, so need a very small code change.