### PR TITLE
Changes to application conf and home controller for login

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ApplicationHomeController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ApplicationHomeController.scala
@@ -102,7 +102,7 @@ class ApplicationHomeController @Inject()(conf: DemouiConfigModule, version: Dem
         val result = Await.result(futureResponse, 10000.millis)
 
         // Any response other than a 200 is assumed to be an authentication failure (e.g. 401)
-        if (result.status != OK) {
+        if (result.status == OK) {
           val key = userName + "_" + (result.json \ "key").as[String]
           Redirect(new Call("GET", req.session.get("referer").getOrElse(default = "/home"))).withSession("api-key" -> key)
         } else Ok(uk.gov.ons.addressIndex.demoui.views.html.login("Authentication failed",version))

--- a/demo-ui/conf/application.conf
+++ b/demo-ui/conf/application.conf
@@ -21,8 +21,9 @@ demoui {
   customErrorTest =  ${?ONS_AI_UI_CUSTOM_ERROR_TEST}
   customErrorProd = true
   customErrorProd =  ${?ONS_AI_UI_CUSTOM_ERROR_PROD}
-  gatewayURL = "https://apigw-in-d-02:9443"
- // gatewayURL = "https://10.50.14.22:9443"
+ // gatewayURL = "https://apigw-in-d-02:9443"
+  gatewayURL = "https://10.50.14.22:9443"
+  gatewayURL = ${?ONS_AI_UI_GATEWAY_URL}
   apiURL{
  // change to host = "http://localhost" to run against local API
     host = "http://addressindex-api-dev.apps.devtest.onsclofo.uk"
@@ -40,3 +41,4 @@ demoui {
 play.ws.timeout.request=1800000
 play.ws.timeout.idle=1800000
 play.ws.timeout.connection=1800000
+play.ws.ssl.loose.acceptAnyCertificate=true

--- a/demo-ui/conf/application.conf
+++ b/demo-ui/conf/application.conf
@@ -21,8 +21,7 @@ demoui {
   customErrorTest =  ${?ONS_AI_UI_CUSTOM_ERROR_TEST}
   customErrorProd = true
   customErrorProd =  ${?ONS_AI_UI_CUSTOM_ERROR_PROD}
- // gatewayURL = "https://apigw-in-d-02:9443"
-  gatewayURL = "https://10.50.14.22:9443"
+  gatewayURL = "https://apigw-in-d-02:9443"
   gatewayURL = ${?ONS_AI_UI_GATEWAY_URL}
   apiURL{
  // change to host = "http://localhost" to run against local API


### PR DESCRIPTION
Old Gateway now working, some small changes required to policy (held in on-site GitLab not public GitHub) and to the  conf and  to  the  home  controller. It  now works, provided the old gateway's IP is specified in Jenkins. New gateway still not quite there.