### PR TITLE
Fix connection reset by peer error

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -45,7 +45,7 @@ class AddressController @Inject()(
     * @param input the address query
     * @return Json response with addresses information
     */
-  def addressQuery(input: String, offset: Option[String] = None, limit: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
+  def addressQuery(input: String, offset: Option[String] = None, limit: Option[String] = None, retry: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
    // logger.info(s"#addressQuery:\ninput $input, offset: ${offset.getOrElse("default")}, limit: ${limit.getOrElse("default")}")
     val startingTime = System.currentTimeMillis()
 
@@ -145,7 +145,14 @@ class AddressController @Inject()(
           writeSplunkLogs(badRequestErrorMessage = FailedRequestToEsError.message)
 
           logger.warn(s"Could not handle individual request (address input), problem with ES ${exception.getMessage}")
-          InternalServerError(Json.toJson(FailedRequestToEs))
+         // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
+          val retry_required = retry.getOrElse("false")
+          if (retry_required.equals("true") && exception.getMessage().equals("Connection reset by peer")) {
+            logger.warn("retry")
+            Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.addressQuery(input,offset,limit,Some("true")))
+          } else {
+            InternalServerError(Json.toJson(FailedRequestToEs))
+          }
       }
 
     }
@@ -157,7 +164,7 @@ class AddressController @Inject()(
     * @param uprn uprn of the address to be fetched
     * @return
     */
-  def uprnQuery(uprn: String): Action[AnyContent] = Action async { implicit req =>
+  def uprnQuery(uprn: String, retry: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
    // logger.info(s"#uprnQuery: uprn: $uprn")
 
     // check API key
@@ -209,7 +216,14 @@ class AddressController @Inject()(
           writeSplunkLogs(badRequestErrorMessage = FailedRequestToEsError.message)
 
           logger.warn(s"Could not handle individual request (uprn), problem with ES ${exception.getMessage}")
-          InternalServerError(Json.toJson(FailedRequestToEs))
+          // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
+          val retry_required = retry.getOrElse("false")
+          if (retry_required.equals("true") && exception.getMessage().equals("Connection reset by peer")) {
+            logger.warn("retry")
+            Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.uprnQuery(uprn,Some("true")))
+          } else {
+            InternalServerError(Json.toJson(FailedRequestToEs))
+          }
       }
     }
   }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -146,8 +146,8 @@ class AddressController @Inject()(
 
           logger.warn(s"Could not handle individual request (address input), problem with ES ${exception.getMessage}")
          // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
-          val retry_required = retry.getOrElse("false")
-          if (retry_required.equals("true") && exception.getMessage().equals("Connection reset by peer")) {
+          val isRetry = retry.getOrElse("false")
+          if (isRetry.equals("false") && exception.getMessage().equals("Connection reset by peer")) {
             logger.warn("retry")
             Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.addressQuery(input,offset,limit,Some("true")))
           } else {
@@ -217,8 +217,8 @@ class AddressController @Inject()(
 
           logger.warn(s"Could not handle individual request (uprn), problem with ES ${exception.getMessage}")
           // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
-          val retry_required = retry.getOrElse("false")
-          if (retry_required.equals("true") && exception.getMessage().equals("Connection reset by peer")) {
+          val isRetry = retry.getOrElse("false")
+          if (isRetry.equals("false") && exception.getMessage().equals("Connection reset by peer")) {
             logger.warn("retry")
             Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.uprnQuery(uprn,Some("true")))
           } else {

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -11,13 +11,15 @@ GET     /                   uk.gov.ons.addressIndex.server.controllers.general.A
 #      description: Specifies the offset from zero, used for pagination (default 0, maximum 1000).
 #    - name: limit
 #      description: Specifies the number of addresses to return (default 10, maximum 100).
+#    - name: retry
+#      description: Flag to indicate this request is a retry (default false).
 #  responses:
 #    200:
 #      description: success
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.AddressBySearchResponseContainer"
 ###
-GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, offset: Option[String], limit: Option[String])
+GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, offset: Option[String], limit: Option[String], retry: Option[String])
 
 ###
 #  summary: Gets an address by UPRN.
@@ -31,7 +33,7 @@ GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressCo
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.AddressByUprnResponseContainer"
 ###
-GET     /addresses/:uprn    uk.gov.ons.addressIndex.server.controllers.AddressController.uprnQuery(uprn)
+GET     /addresses/:uprn    uk.gov.ons.addressIndex.server.controllers.AddressController.uprnQuery(uprn, retry: Option[String])
 
 ###
 #  summary: Test elastic is connected.


### PR DESCRIPTION
After a period of inactivity, when using the Elastic4S HTTP connector (rather than the TCP), a request may fail with "Connection reset by peer". When this happens retrying the request does the trick. This PR makes the /addresses endpoint (input string or uprn) perform one and only one retry.