### PR TITLE
Add ambiguity penalty to response

### DIFF
--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
@@ -111,7 +111,8 @@ class AddressIndexClientMock @Inject()(override val client : WSClient,
     unitScore = 0d,
     buildingScoreDebug = "0",
     localityScoreDebug = "0",
-    unitScoreDebug = "0")
+    unitScoreDebug = "0",
+    ambiguityPenalty = 1d)
 
   val mockAddressResponseAddress = AddressResponseAddress(
     uprn = "",

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/AddressResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/AddressResponse.scala
@@ -639,7 +639,8 @@ case class AddressResponseScore (
   unitScore: Double,
   buildingScoreDebug: String,
   localityScoreDebug: String,
-  unitScoreDebug: String
+  unitScoreDebug: String,
+  ambiguityPenalty: Double
 )
 
 object AddressResponseScore {

--- a/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
@@ -145,7 +145,8 @@ object HopperScoreHelper  {
       unitScore,
       respBuildingScoreDebug,
       respLocalityScoreDebug,
-      respUnitScoreDebug)
+      respUnitScoreDebug,
+      ambiguityPenalty)
 
     address.copy(bespokeScore = Some(bespokeScore))
   }

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -133,7 +133,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
     unitScore = 0,
     buildingScoreDebug = "0",
     localityScoreDebug = "0",
-    unitScoreDebug = "0")
+    unitScoreDebug = "0",
+    ambiguityPenalty = 1d)
 
   val givenRelativeResponse = AddressResponseRelative.fromRelative(givenRelative)
 

--- a/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
@@ -165,7 +165,8 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
     unitScore = 0d,
     buildingScoreDebug = "0",
     localityScoreDebug = "0",
-    unitScoreDebug = "0")
+    unitScoreDebug = "0",
+    ambiguityPenalty = 1d)
 
   val mockBespokeScore = AddressResponseScore(
     objectScore = -1.0d,
@@ -175,7 +176,8 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
     unitScore = -1.0d,
     buildingScoreDebug = "91",
     localityScoreDebug = "9111",
-    unitScoreDebug = "0999")
+    unitScoreDebug = "0999",
+    ambiguityPenalty = 1d)
 
   val mockAddressResponseAddress = AddressResponseAddress(
     uprn = "",


### PR DESCRIPTION
This change exposes the underlying ambiguity penalty on the API response under the bespokescore section. 