### PR TITLE
Demo UI config for routing via gateway (JIRA 77)

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientInstance.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientInstance.scala
@@ -10,5 +10,5 @@ class AddressIndexClientInstance @Inject()(override val client : WSClient,
                                            conf : DemouiConfigModule) extends AddressIndexClient {
   //  set config entry to "http://localhost:9001" to run locally
   //  set config entry to "https://addressindexapitest.cfapps.io" to run from cloud
-  override def host: String = s"${conf.config.apiURL.host}:${conf.config.apiURL.port}"
+  override def host: String = s"${conf.config.apiURL.host}:${conf.config.apiURL.port}${conf.config.apiURL.gatewayPath}"
 }

--- a/demo-ui/conf/application.conf
+++ b/demo-ui/conf/application.conf
@@ -41,6 +41,9 @@ demoui {
  // change to port = 9001 to run against local API
     port = 80
     port =  ${?ONS_AI_UI_API_PORT}
+    // gatewayPath = "/ai/master"
+    gatewayPath = ""
+    gatewayPath = ${?ONS_AI_UI_API_GATEWAY_POLICY_PATH}
   }
   limit = 10
   offset = 0

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -214,7 +214,8 @@ case class BatchConfig(
 
 case class ApiConfig(
   host: String,
-  port: Int
+  port: Int,
+  gatewayPath: String
 )
 
 case class DemouiConfig (


### PR DESCRIPTION
To use the API via the Gateway, its IP needs to be entered in the API URL variable, port 8443 as the API PORT and the new variable ONS_AI_UI_API_GATEWAY_POLICY_PATH needs to be set to the path the policies are expecting for the current environment.