### PR TITLE
Make retry work with Netty (or Akka)

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -219,8 +219,8 @@ class AddressController @Inject()(
           logger.warn(s"Could not handle individual request (uprn), problem with ES ${exception.getMessage}")
           // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
           val isRetry = retry.getOrElse("false")
-          if (isRetry.equals("false") && exception.getMessage().equals("Connection reset by peer")) {
-            logger.warn("retry")
+          if (isRetry.equals("false")) {
+            logger.warn("retrying uprn request")
             Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.uprnQuery(uprn,Some("true")))
           } else {
             InternalServerError(Json.toJson(FailedRequestToEs))

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -145,10 +145,11 @@ class AddressController @Inject()(
           writeSplunkLogs(badRequestErrorMessage = FailedRequestToEsError.message)
 
           logger.warn(s"Could not handle individual request (address input), problem with ES ${exception.getMessage}")
-         // if there is a connection reset by peer error due to inactivity we want to retry once to wake up the index connection
+         // if there is a connection reset by peer or similar error due to inactivity
+         // we want to retry once to wake up the index connection
           val isRetry = retry.getOrElse("false")
-          if (isRetry.equals("false") && exception.getMessage().equals("Connection reset by peer")) {
-            logger.warn("retry")
+          if (isRetry.equals("false")) {
+            logger.warn("retrying single match request")
             Redirect(uk.gov.ons.addressIndex.server.controllers.routes.AddressController.addressQuery(input,offset,limit,Some("true")))
           } else {
             InternalServerError(Json.toJson(FailedRequestToEs))

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -478,8 +478,8 @@ class AddressControllerSpec extends PlaySpec with Results{
         errors = Seq(FailedRequestToEsError)
       ))
 
-      // When
-      val result = controller.addressQuery("some query").apply(FakeRequest())
+      // When - retry param must be true
+      val result = controller.addressQuery("some query", Some("0"), Some("10"), Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -506,8 +506,8 @@ class AddressControllerSpec extends PlaySpec with Results{
         errors = Seq(FailedRequestToEsError)
       ))
 
-      // When
-      val result = controller.uprnQuery("12345").apply(FakeRequest())
+      // When - retry parameter must be true
+      val result = controller.uprnQuery("12345",Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then


### PR DESCRIPTION
Retry no longer tests message text which depends on server. Unit tests now include retry parameter for failures.