### PR TITLE
Fix retry issues

### DIFF
--- a/server/conf/routes
+++ b/server/conf/routes
@@ -12,7 +12,9 @@ GET     /                   uk.gov.ons.addressIndex.server.controllers.general.A
 #    - name: limit
 #      description: Specifies the number of addresses to return (default 10, maximum 100).
 #    - name: retry
-#      description: Flag to indicate this request is a retry (default false).
+#      description: Number of retries to attempt. System default if omitted or above allowed maximum.
+#    - name: filter
+#      description: Classsification code filter. Can be pattern match e.g. ZW*, exact match e.g. RD06 or a preset keyword such as residential or commercial
 #  responses:
 #    200:
 #      description: success

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -479,7 +479,7 @@ class AddressControllerSpec extends PlaySpec with Results{
       ))
 
       // When - retry param must be true
-      val result = controller.addressQuery("some query", Some("0"), Some("10"), Some("true")).apply(FakeRequest())
+      val result = controller.addressQuery("some query", Some("0"), Some("10"), Some("0")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -507,7 +507,7 @@ class AddressControllerSpec extends PlaySpec with Results{
       ))
 
       // When - retry parameter must be true
-      val result = controller.uprnQuery("12345",Some("true")).apply(FakeRequest())
+      val result = controller.uprnQuery("12345",Some("0")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then


### PR DESCRIPTION
Filter and retry params in wrong order on one of the  requests
Sometimes need more that one retry so allow up to 5 (max)