### PR TITLE
Move hierarchy call to server side (and separate AJAX URL)

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
 import uk.gov.ons.addressIndex.demoui.client.AddressIndexClientInstance
 import uk.gov.ons.addressIndex.demoui.model._
 import uk.gov.ons.addressIndex.demoui.modules.DemouiConfigModule
-import uk.gov.ons.addressIndex.demoui.utils.ClassHierarchy
+import uk.gov.ons.addressIndex.demoui.utils.{ClassHierarchy, RelativesExpander}
 import uk.gov.ons.addressIndex.model.server.response.{AddressBySearchResponseContainer, AddressByUprnResponseContainer}
 import uk.gov.ons.addressIndex.model.{AddressIndexSearchRequest, AddressIndexUPRNRequest}
 import uk.gov.ons.addressIndex.demoui.modules.DemoUIAddressIndexVersionModule
@@ -36,6 +36,7 @@ class ClericalToolController @Inject()(
   langs: Langs,
   apiClient: AddressIndexClientInstance,
   classHierarchy: ClassHierarchy,
+  relativesExpander: RelativesExpander,
   version: DemoUIAddressIndexVersionModule
   )(implicit ec: ExecutionContext) extends BaseController with I18nSupport {
 
@@ -45,7 +46,8 @@ class ClericalToolController @Inject()(
   val pageSize = conf.config.limit
   val maxOff = conf.config.maxOffset
   val maxPages = (maxOff + pageSize - 1) / pageSize
-  val apiUrl = conf.config.apiURL.host + ":" + conf.config.apiURL.port + conf.config.apiURL.gatewayPath
+  // val apiUrl = conf.config.apiURL.host + ":" + conf.config.apiURL.port + conf.config.apiURL.gatewayPath
+  val apiUrl = conf.config.apiURL.ajaxHost + ":" + conf.config.apiURL.ajaxPort + conf.config.apiURL.gatewayPath
 
   /**
     * Present empty form for user to input address
@@ -365,6 +367,12 @@ class ClericalToolController @Inject()(
         val classCodes: Map[String, String] = nags.map(nag =>
           (nag.uprn , classHierarchy.analyseClassCode(nag.classificationCode))).toMap
 
+        val rels = resp.response.address.map {add =>
+          add.relatives
+        }
+        val expandedRels = Try(relativesExpander.expandRelatives(apiKey, rels.getOrElse(Seq()))).getOrElse(Seq())
+       // logger info("expanded rels = " + expandedRels.toString())
+
         val warningMessage =
           if (resp.status.code == 200) None
           else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
@@ -376,6 +384,7 @@ class ClericalToolController @Inject()(
           warningMessage = warningMessage,
           addressByUprnResponse = Some(resp.response),
           classification = Some(classCodes),
+          expandedRels = Some(expandedRels),
           version = version,
           isClerical = true,
           apiUrl = apiUrl,

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
@@ -1,8 +1,8 @@
 package uk.gov.ons.addressIndex.demoui.controllers
 
 import java.util.UUID
-import javax.inject.{Inject, Singleton}
 
+import javax.inject.{Inject, Singleton}
 import org.apache.commons.lang3.StringUtils
 import play.api.Logger
 import play.api.data.Forms._
@@ -12,7 +12,7 @@ import play.api.mvc._
 import uk.gov.ons.addressIndex.demoui.client.AddressIndexClientInstance
 import uk.gov.ons.addressIndex.demoui.model._
 import uk.gov.ons.addressIndex.demoui.modules.{DemoUIAddressIndexVersionModule, DemouiConfigModule}
-import uk.gov.ons.addressIndex.demoui.utils.ClassHierarchy
+import uk.gov.ons.addressIndex.demoui.utils.{ClassHierarchy, RelativesExpander}
 import uk.gov.ons.addressIndex.model.{AddressIndexSearchRequest, AddressIndexUPRNRequest}
 import uk.gov.ons.addressIndex.model.server.response.{AddressBySearchResponseContainer, AddressByUprnResponseContainer}
 
@@ -35,6 +35,7 @@ class SingleMatchController @Inject()(
    langs: Langs,
    apiClient: AddressIndexClientInstance,
    classHierarchy: ClassHierarchy,
+   relativesExpander: RelativesExpander,
    version: DemoUIAddressIndexVersionModule
 )(implicit ec: ExecutionContext) extends BaseController with I18nSupport {
 
@@ -44,8 +45,8 @@ class SingleMatchController @Inject()(
   val pageSize = conf.config.limit
   val maxOff = conf.config.maxOffset
   val maxPages = (maxOff + pageSize - 1) / pageSize
-  val apiUrl = conf.config.apiURL.host + ":" + conf.config.apiURL.port + conf.config.apiURL.gatewayPath
-
+  // val apiUrl = conf.config.apiURL.host + ":" + conf.config.apiURL.port + conf.config.apiURL.gatewayPath
+  val apiUrl = conf.config.apiURL.ajaxHost + ":" + conf.config.apiURL.ajaxPort + conf.config.apiURL.gatewayPath
   /**
     * Present empty form for user to input address
     *
@@ -314,6 +315,12 @@ class SingleMatchController @Inject()(
           val classCodes: Map[String, String] = nags.map(nag =>
             (nag.uprn, classHierarchy.analyseClassCode(nag.classificationCode))).toMap
 
+          val rels = resp.response.address.map {add =>
+            add.relatives
+          }
+          val expandedRels = Try(relativesExpander.expandRelatives(apiKey, rels.getOrElse(Seq()))).getOrElse(Seq())
+     //     logger info("expanded rels = " + expandedRels.toString())
+
           val warningMessage =
             if (resp.status.code == 200) None
             else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
@@ -325,6 +332,7 @@ class SingleMatchController @Inject()(
             warningMessage = warningMessage,
             addressByUprnResponse = Some(resp.response),
             classification = Some(classCodes),
+            expandedRels = Some(expandedRels),
             version = version,
             isClerical = false,
             apiUrl = apiUrl,
@@ -382,6 +390,12 @@ class SingleMatchController @Inject()(
           val classCodes: Map[String, String] = nags.map(nag =>
             (nag.uprn, classHierarchy.analyseClassCode(nag.classificationCode))).toMap
 
+          val rels = resp.response.address.map {add =>
+            add.relatives
+          }
+          val expandedRels = Try(relativesExpander.expandRelatives(apiKey, rels.getOrElse(Seq()))).getOrElse(Seq())
+          //logger info("expanded rels = " + expandedRels.toString())
+
           val warningMessage =
             if (resp.status.code == 200) None
             else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
@@ -393,6 +407,7 @@ class SingleMatchController @Inject()(
             warningMessage = warningMessage,
             addressByUprnResponse = Some(resp.response),
             classification = Some(classCodes),
+            expandedRels = Some(expandedRels),
             version = version,
             isClerical = true,
             apiUrl = apiUrl,

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
@@ -1,0 +1,53 @@
+package uk.gov.ons.addressIndex.demoui.utils
+
+import java.util.UUID
+
+import uk.gov.ons.addressIndex.model.db.index.{ExpandedRelative, ExpandedSibling, Relative}
+import uk.gov.ons.addressIndex.model.server.response.{AddressByUprnResponseContainer, AddressResponseRelative}
+import javax.inject.{Inject, Singleton}
+import uk.gov.ons.addressIndex.demoui.client.AddressIndexClientInstance
+import uk.gov.ons.addressIndex.model.AddressIndexUPRNRequest
+
+import scala.language.postfixOps
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+@Singleton
+class RelativesExpander @Inject ()(
+  apiClient: AddressIndexClientInstance
+)(implicit ec: ExecutionContext) {
+
+  def expandRelatives(apiKey: String, relatives: Seq[AddressResponseRelative]): Seq[ExpandedRelative] = {
+    relatives.map{rel => expandRelative(apiKey,rel)}
+  }
+
+  def expandRelative (apiKey: String, rel: AddressResponseRelative):  ExpandedRelative = {
+    ExpandedRelative (
+      rel.level,
+      getExpandedSiblings(apiKey, rel.siblings)
+    )
+  }
+
+  def getExpandedSiblings(apiKey: String, uprns: Seq[Long]): Seq[ExpandedSibling] = {
+    uprns.map(uprn => {
+      new ExpandedSibling(uprn,Await.result(getAddressFromUprn(apiKey,uprn), 1 seconds))
+    })
+  }
+
+  def getAddressFromUprn(apiKey: String, uprn: Long): Future[String] = {
+    val numericUPRN = BigInt(uprn)
+    apiClient.uprnQuery(
+      AddressIndexUPRNRequest(
+        uprn = numericUPRN,
+        id = UUID.randomUUID,
+        apiKey = apiKey
+      )
+    ).map { resp: AddressByUprnResponseContainer =>
+      resp.response.address.map ({ add =>
+        add.formattedAddress
+      }).getOrElse(uprn + "not found")
+    }
+  }
+}
+

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/addressResult.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/addressResult.scala.html
@@ -1,4 +1,5 @@
 @import uk.gov.ons.addressIndex.model.server.response.AddressResponseAddress
+@import uk.gov.ons.addressIndex.model.db.index.ExpandedRelative
 @import uk.gov.ons.addressIndex.parsers.Tokens
 @import java.text.SimpleDateFormat
 
@@ -7,6 +8,7 @@ address: AddressResponseAddress,
 filter: String,
 maxScore: Double,
 classification: Option[Map[String, String]],
+expandedRels: Option[Seq[ExpandedRelative]],
 tokens: Map[String, String] = Map.empty[String, String],
 pageNum: Int = 0,
 index: Int = 0,
@@ -493,7 +495,7 @@ apiKey: String = ""
 
             <section class="address-result-hierarchy">
                 <h2>@messages("addressresult.address_hierarchy")</h2>
-                @address.relatives.zipAll(List("Primary", "Secondary", "Tertiary", "Quaternary"), "", "").filter(element => element._1 != "").map { case (relative: uk.gov.ons.addressIndex.model.server.response.AddressResponseRelative, position: String) =>
+                @expandedRels.getOrElse(Seq()).zipAll(List("Primary", "Secondary", "Tertiary", "Quaternary", "Quinternary"), "", "").filter(element => element._1 != "").map { case (expandedRelative: uk.gov.ons.addressIndex.model.db.index.ExpandedRelative, position: String) =>
                 <article class="address-result-hierarchy-single">
                     @if(position == "Primary") {<h3><strong>@messages("addressresult.position_primary")</strong></h3>}
                     @if(position == "Secondary") {<h3><strong>@messages("addressresult.position_secondary")</strong></h3>}
@@ -507,8 +509,12 @@ apiKey: String = ""
                         </tr>
                         </thead>
                         <tbody id="@position@address.uprn">
-                        @relative.siblings.sorted.map { uprn =>
-                        <script>hierarchyResult("@uprn", "@position@address.uprn", '@apiUrl', '@apiKey')</script>
+                        @expandedRelative.siblings.map { expandedSibling =>
+                        <tr><td><a href="@expandedSibling.uprn">@expandedSibling.uprn</a></td>
+                            <td>
+                                @{expandedSibling.formattedAddress.substring(0, expandedSibling.formattedAddress.lastIndexOf(",") + 1).toLowerCase.split(" ").map(_.capitalize).mkString(" ") + " " + expandedSibling.formattedAddress.substring(expandedSibling.formattedAddress.lastIndexOf(",") + 1, expandedSibling.formattedAddress.length)}
+                            </td>
+                        </tr>
                         }
                         </tbody>
                     </table>

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/result.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/result.scala.html
@@ -1,11 +1,13 @@
 @import uk.gov.ons.addressIndex.demoui.model.ui.Navigation
 @import uk.gov.ons.addressIndex.demoui.modules.DemoUIAddressIndexVersionModule
+@import uk.gov.ons.addressIndex.model.db.index.ExpandedRelative
 @(
 singleSearchForm: Form[uk.gov.ons.addressIndex.demoui.model.SingleSearchForm],
 filter: Option[String],
 warningMessage : Option[String],
 addressByUprnResponse: Option[uk.gov.ons.addressIndex.model.server.response.AddressByUprnResponse],
 classification: Option[Map[String,String]],
+expandedRels: Option[Seq[ExpandedRelative]],
 version: DemoUIAddressIndexVersionModule,
 isClerical: Boolean,
 apiUrl: String = "",
@@ -42,6 +44,7 @@ apiKey: String
                     singleSearchForm("filter").value.getOrElse(""),
                     address.underlyingScore,
                     classification,
+                    expandedRels,
                     isClerical = isClerical,
                     index = -1,
                     expandRow = -1,

--- a/demo-ui/conf/application.conf
+++ b/demo-ui/conf/application.conf
@@ -41,6 +41,13 @@ demoui {
  // change to port = 9001 to run against local API
     port = 80
     port =  ${?ONS_AI_UI_API_PORT}
+    ajaxHost = "http://addressindex-api-dev.apps.devtest.onsclofo.uk"
+    ajaxHost =  ${?ONS_AI_UI_API_URI}
+    ajaxHost =  ${?ONS_AI_UI_API_AJAX_URI}
+    // change to port = 9001 to run against local API
+    ajaxPort = 80
+    ajaxPort =  ${?ONS_AI_UI_API_PORT}
+    ajaxPort =  ${?ONS_AI_UI_API_AJAX_PORT}
     // gatewayPath = "/ai/master"
     gatewayPath = ""
     gatewayPath = ${?ONS_AI_UI_API_GATEWAY_POLICY_PATH}

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
@@ -1,10 +1,9 @@
 package uk.gov.ons.addressIndex.demoui.client
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.libs.ws.WSClient
 import uk.gov.ons.addressIndex.demoui.modules.DemouiConfigModule
-import uk.gov.ons.addressIndex.model.{AddressIndexSearchRequest, AddressIndexPostcodeRequest}
+import uk.gov.ons.addressIndex.model.{AddressIndexPostcodeRequest, AddressIndexSearchRequest, AddressIndexUPRNRequest}
 import uk.gov.ons.addressIndex.model.db.index.{CrossRef, Relative}
 import uk.gov.ons.addressIndex.model.server.response._
 
@@ -156,6 +155,10 @@ class AddressIndexClientMock @Inject()(override val client : WSClient,
     maxScore = 1f
   )
 
+  val mockAddressByUprnResponse = AddressByUprnResponse (
+    address = Some(mockAddressResponseAddress: AddressResponseAddress)
+  )
+
   val mockSearchResponseContainer = AddressBySearchResponseContainer (
     apiVersion = "mockApi",
     dataVersion = "mockData",
@@ -172,10 +175,21 @@ class AddressIndexClientMock @Inject()(override val client : WSClient,
     errors = Seq.empty[AddressResponseError]
   )
 
+  val mockUprnResponseContainer = AddressByUprnResponseContainer (
+    apiVersion = "mockApi",
+    dataVersion = "mockData",
+    response = mockAddressByUprnResponse,
+    status = mockAddressResponseStatus,
+    errors = Seq.empty[AddressResponseError]
+  )
+
 
   override def addressQuery(request: AddressIndexSearchRequest)(implicit ec: ExecutionContext): Future[AddressBySearchResponseContainer] =
     Future.successful(mockSearchResponseContainer)
 
   override def postcodeQuery(request: AddressIndexPostcodeRequest)(implicit ec: ExecutionContext): Future[AddressByPostcodeResponseContainer] =
     Future.successful(mockPostcodeResponseContainer)
+
+  override def uprnQuery(request: AddressIndexUPRNRequest)(implicit ec: ExecutionContext): Future[AddressByUprnResponseContainer] =
+    Future.successful(mockUprnResponseContainer)
 }

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/controllers/ClientToolTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/controllers/ClientToolTest.scala
@@ -8,7 +8,7 @@ import play.api.test.WithApplication
 import uk.gov.ons.addressIndex.demoui.modules.{DemoUIAddressIndexVersionModule, DemouiConfigModule}
 import play.api.test.FakeRequest
 import uk.gov.ons.addressIndex.demoui.client.{AddressIndexClientInstance, AddressIndexClientMock}
-import uk.gov.ons.addressIndex.demoui.utils.ClassHierarchy
+import uk.gov.ons.addressIndex.demoui.utils.{ClassHierarchy, RelativesExpander}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -28,6 +28,7 @@ class ClientToolTest extends PlaySpec with Results {
       val controllerComponents = app.injector.instanceOf[ControllerComponents]
       val expectedString = "GATE REACH"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val inputAddress = "7 GATE REACH EXETER EX2 6GA"
@@ -39,6 +40,7 @@ class ClientToolTest extends PlaySpec with Results {
         langs,
         apiClient.asInstanceOf[AddressIndexClientInstance],
         classHierarchy,
+        expandedRels,
         version)
         .doMatchWithInput(inputAddress, filter, Some(1), Some(1)).apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)
@@ -58,6 +60,7 @@ class ClientToolTest extends PlaySpec with Results {
       val controllerComponents = app.injector.instanceOf[ControllerComponents]
       val expectedString = "Residential"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val inputAddress = "7 GATE REACH EXETER EX2 6GA"
@@ -69,6 +72,7 @@ class ClientToolTest extends PlaySpec with Results {
         langs,
         apiClient.asInstanceOf[AddressIndexClientInstance],
         classHierarchy,
+        expandedRels,
         version)
         .doMatchWithInput(inputAddress, filter, Some(1), Some(1)).apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchTest.scala
@@ -7,7 +7,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, WithApplication}
 import uk.gov.ons.addressIndex.demoui.client.{AddressIndexClientInstance, AddressIndexClientMock}
 import uk.gov.ons.addressIndex.demoui.modules.{DemoUIAddressIndexVersionModule, DemouiConfigModule}
-import uk.gov.ons.addressIndex.demoui.utils.ClassHierarchy
+import uk.gov.ons.addressIndex.demoui.utils.{ClassHierarchy, RelativesExpander}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -27,6 +27,7 @@ class SingleMatchTest extends PlaySpec with Results {
       val controllerComponents = app.injector.instanceOf[ControllerComponents]
       val expectedString = "Search for an address"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val response = new SingleMatchController(
@@ -36,6 +37,7 @@ class SingleMatchTest extends PlaySpec with Results {
         langs,
         apiClient,
         classHierarchy,
+        expandedRels,
         version)
         .showSingleMatchPage().apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)
@@ -55,6 +57,7 @@ class SingleMatchTest extends PlaySpec with Results {
       val controllerComponents = app.injector.instanceOf[ControllerComponents]
       val expectedString = "<form action=\"/addresses/search\" method=\"POST\" >"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val response = new SingleMatchController(
@@ -64,6 +67,7 @@ class SingleMatchTest extends PlaySpec with Results {
         langs,
         apiClient,
         classHierarchy,
+        expandedRels,
         version)
         .showSingleMatchPage().apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)
@@ -83,7 +87,7 @@ class SingleMatchTest extends PlaySpec with Results {
       val controllerComponents = app.injector.instanceOf[ControllerComponents]
       val expectedString = "<span class=\"error\" onclick=\"setFocus('address');\">Please enter an address</span>"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
-
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
       // When
       val response = new SingleMatchController(
         controllerComponents,
@@ -92,6 +96,7 @@ class SingleMatchTest extends PlaySpec with Results {
         langs,
         apiClient,
         classHierarchy,
+        expandedRels,
         version)
         .doMatch().apply(FakeRequest(POST,"/addresses/search").withFormUrlEncodedBody("address" -> "").withSession("api-key" -> ""))
       val content = contentAsString(response)
@@ -113,6 +118,7 @@ class SingleMatchTest extends PlaySpec with Results {
       val inputAddress = "7 EX2 6GA"
       val filter = ""
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val response = new SingleMatchController(
@@ -122,6 +128,7 @@ class SingleMatchTest extends PlaySpec with Results {
         langs,
         apiClient.asInstanceOf[AddressIndexClientInstance],
         classHierarchy,
+        expandedRels,
         version)
       .doMatchWithInput(inputAddress, Some(filter), Some(1)).apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)
@@ -143,6 +150,7 @@ class SingleMatchTest extends PlaySpec with Results {
       val inputAddress = "7 EX2 6GA"
       val filter = "RD"
       val classHierarchy  = app.injector.instanceOf(classOf[ClassHierarchy])
+      val expandedRels = app.injector.instanceOf(classOf[RelativesExpander])
 
       // When
       val response = new SingleMatchController(
@@ -152,6 +160,7 @@ class SingleMatchTest extends PlaySpec with Results {
         langs,
         apiClient.asInstanceOf[AddressIndexClientInstance],
         classHierarchy,
+        expandedRels,
         version)
         .doMatchWithInput(inputAddress, Some(filter), Some(1)).apply(FakeRequest().withSession("api-key" -> ""))
       val content = contentAsString(response)

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpanderTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpanderTest.scala
@@ -1,0 +1,38 @@
+package uk.gov.ons.addressIndex.demoui.utils
+
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.i18n._
+import play.api.mvc.ControllerComponents
+import play.api.test.WithApplication
+import uk.gov.ons.addressIndex.demoui.client.AddressIndexClientMock
+import uk.gov.ons.addressIndex.model.db.index.{ExpandedRelative, ExpandedSibling, Relative}
+import uk.gov.ons.addressIndex.model.server.response.AddressResponseRelative
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RelativesExpanderTest extends FlatSpec with Matchers {
+  "RelativesExpander" should
+    "add formattedAddresses to siblings in supplied relatives" in new WithApplication {
+    val messagesApi = app.injector.instanceOf[MessagesApi]
+    val langs = app.injector.instanceOf[Langs]
+    val apiClient = app.injector.instanceOf[AddressIndexClientMock]
+    val controllerComponents = app.injector.instanceOf[ControllerComponents]
+    val relativesExpander = new RelativesExpander (apiClient)
+    val rel1 = new AddressResponseRelative(1,Seq(1L),Seq())
+    val rel2 = new AddressResponseRelative(2,Seq(2L,3L),Seq(1L))
+    val rels = Seq(rel1,rel2)
+
+    // Given
+    val esib1 = new ExpandedSibling(1,"7, GATE REACH, EXETER, EX2 9GA")
+    val esib2 = new ExpandedSibling(2,"7, GATE REACH, EXETER, EX2 9GA")
+    val esib3 = new ExpandedSibling(3,"7, GATE REACH, EXETER, EX2 9GA")
+    val ex1 = new ExpandedRelative(1,Seq(esib1))
+    val ex2 = new ExpandedRelative(2,Seq(esib2,esib3))
+    val expectedSeq = Seq(ex1,ex2)
+
+    // When
+    val result = relativesExpander.expandRelatives("antidisestablishmentarianism",rels)
+
+    result shouldBe expectedSeq
+  }
+
+  }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -219,6 +219,8 @@ case class BatchConfig(
 case class ApiConfig(
   host: String,
   port: Int,
+  ajaxHost: String,
+  ajaxPort: String,
   gatewayPath: String
 )
 

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/ExpandedRelative.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/ExpandedRelative.scala
@@ -1,0 +1,16 @@
+package uk.gov.ons.addressIndex.model.db.index
+
+/**
+  * Relative Expander DTO
+  * Relatives response contains a sequence of Relative objects, one per level
+  * Expanded vesion has siblings with formattedAdresses for the UI
+  */
+case class ExpandedRelative(
+  level: Int,
+  siblings: Seq[ExpandedSibling]
+)
+
+case class ExpandedSibling(
+  uprn: Long,
+  formattedAddress: String
+)


### PR DESCRIPTION
This change makes the hierarchy information into a server-side call to avoid making AJAX calls to the Gateway. Despite this, the ability to have a separate AJAX URL is still enabled also, as it is useful for demos.

Note that the hierarchy expander is not quite 100% non-blocking, but the awaited UPRN calls are very fast.