### PR TITLE
Set minimum number of addresses for bulk scoring (JIRA 1000)

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -699,9 +699,7 @@ class AddressController @Inject()(
 
     val defaultBatchSize = conf.config.bulk.batch.perBatch
     val resultLimit = limitperaddress.getOrElse(conf.config.bulk.limitperaddress)
-    // currently don't get extra addresses
-    val expandedLimit = resultLimit
-    val results: Stream[Seq[AddressBulkResponseAddress]] = iterateOverRequestsWithBackPressure(requestData, defaultBatchSize, Some(expandedLimit), configOverwrite, historical, matchThreshold)
+    val results: Stream[Seq[AddressBulkResponseAddress]] = iterateOverRequestsWithBackPressure(requestData, defaultBatchSize, Some(resultLimit), configOverwrite, historical, matchThreshold)
 
     logger.info(s"#bulkQuery processed")
 

--- a/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
@@ -43,8 +43,6 @@ object HopperScoreHelper  {
     val startingTime = System.currentTimeMillis()
     val localityParams = addresses.map(address => getLocalityParams(AddressResponseAddress.fromHybridAddress(address.hybridAddress),tokens))
     val scoredAddresses = addresses.map(address => addScoresToAddress(AddressResponseAddress.fromHybridAddress(address.hybridAddress), tokens, localityParams, elasticDenominator))
-    val scores = scoredAddresses.map(sAddress => sAddress.confidenceScore)
-
     val endingTime = System.currentTimeMillis()
     logger.trace("Hopper Score calucation time = "+(endingTime-startingTime)+" milliseconds")
     scoredAddresses


### PR DESCRIPTION
With limitperaddress=1 the confidence scores are wrong and the lower the limit the higher the risk that the best match according to the confidence score will not be returned (when it not in the first one or two according to the elastic score). This change ensures that at least 5 address results are always retrieved and scored, then sorted, then thresholded, then limited to the limitperaddress value. 