### PR TITLE
Result Fetching Optimisation (JIRA 1000)

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/clericalTool.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/clericalTool.scala.html
@@ -74,8 +74,7 @@ apiKey: String
             @addressBySearchResponse.map { aresponse =>
                 <section class="match-results-container col-12">
                     <div class="match-results-count saturn">
-                        @addressBySearchResponse.map { aresponse =>
-                        @if(aresponse.sampleSize == aresponse.total) {
+                     @if(aresponse.sampleSize == aresponse.total) {
                         <div class="standout">@messages("results.foundatleastpre") @aresponse.total @messages("results.foundpost")</div>
                         }else{
                         <div class="standout">@messages("results.foundexactpre") @aresponse.total @messages("results.foundpost")</div>

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/clericalTool.scala.html
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/views/clericalTool.scala.html
@@ -73,10 +73,16 @@ apiKey: String
 
             @addressBySearchResponse.map { aresponse =>
                 <section class="match-results-container col-12">
-
                     <div class="match-results-count saturn">
-                        <div class="standout">@messages("postcode.foundpre") @aresponse.total @messages("postcode.foundpost")</div>
+                        @addressBySearchResponse.map { aresponse =>
+                        @if(aresponse.sampleSize == aresponse.total) {
+                        <div class="standout">@messages("results.foundatleastpre") @aresponse.total @messages("results.foundpost")</div>
+                        }else{
+                        <div class="standout">@messages("results.foundexactpre") @aresponse.total @messages("results.foundpost")</div>
+                        }
                     </div>
+
+
                     <div class="match-results">
 
                         @aresponse.addresses.zipWithIndex.map{ case (address, index) =>

--- a/demo-ui/conf/application.conf
+++ b/demo-ui/conf/application.conf
@@ -57,7 +57,7 @@ demoui {
   limit = 10
   offset = 0
   maxLimit = 100
-  maxOffset = 1000
+  maxOffset = 250
 }
 
 akka.http.server.request-timeout = 900s

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -218,9 +218,9 @@ addressIndex {
     defaultLimitPostcode=100
     defaultOffset=0
     maximumLimit=100
-    maximumOffset=1000
+    maximumOffset=250
     matchThreshold=5
-    minimumSample=20
+    minimumSample=5
     minimumSample = ${?ONS_AI_API_MIN_SAMPLE_SINGLE}
   }
   bulk{


### PR DESCRIPTION
This is a small change to set defaults in the config file following  performance testing of the new scoring code. The settings can be overridden in Jenkins. Investigations  (reported on JIRA, Confluence page to follow) showed that we cannot test large numbers of addresses without a significant performance hit, so the minima for the single and bulk are staying quite low. It has also been necessary to reduce the maximum offset to avoid excessive response  size from ES.