### PR TITLE
Fix for AWS ES. No longer passing in default credentials.

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/model/dao/AddressIndexElasticClientProvider.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/model/dao/AddressIndexElasticClientProvider.scala
@@ -68,7 +68,7 @@ class AddressIndexElasticClientProvider @Inject()(conf: AddressIndexConfigModule
     }
   }, new HttpClientConfigCallback {
     override def customizeHttpClient(httpClientBuilder: HttpAsyncClientBuilder) = {
-      httpClientBuilder.setDefaultCredentialsProvider(provider)
+//      httpClientBuilder.setDefaultCredentialsProvider(provider)
       httpClientBuilder.setSSLContext(context)
     }
   })


### PR DESCRIPTION
Tested on internal ES - no issue.