### PR TITLE
Hopper Score efficiency fix

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
@@ -2,7 +2,7 @@ package uk.gov.ons.addressIndex.server.utils
 
 import play.api.Logger
 import uk.gov.ons.addressIndex.model.db.BulkAddress
-import uk.gov.ons.addressIndex.model.server.response.{AddressResponseAddress, AddressResponseRelative, AddressResponseScore}
+import uk.gov.ons.addressIndex.model.server.response.{AddressResponseAddress, AddressResponseScore}
 import uk.gov.ons.addressIndex.parsers.Tokens
 
 import scala.util.Try
@@ -33,7 +33,7 @@ object HopperScoreHelper  {
   def getScoresForAddresses(addresses: Seq[AddressResponseAddress], tokens: Map[String, String], elasticDenominator: Double): Seq[AddressResponseAddress] = {
     val startingTime = System.currentTimeMillis()
     val localityParams = addresses.map(address => getLocalityParams(address,tokens))
-    val scoredAddresses = addresses.map(address => addScoresToAddress(address, tokens, localityParams, elasticDenominator))
+    val scoredAddresses = addresses.zipWithIndex.map{case (address, index) => addScoresToAddress(index, address, tokens, localityParams, elasticDenominator)}
     val endingTime = System.currentTimeMillis()
     logger.trace("Hopper Score calucation time = "+(endingTime-startingTime)+" milliseconds")
     scoredAddresses
@@ -42,7 +42,7 @@ object HopperScoreHelper  {
   def getScoresForBulks(addresses: Seq[BulkAddress], tokens: Map[String, String], elasticDenominator: Double): Seq[AddressResponseAddress] = {
     val startingTime = System.currentTimeMillis()
     val localityParams = addresses.map(address => getLocalityParams(AddressResponseAddress.fromHybridAddress(address.hybridAddress),tokens))
-    val scoredAddresses = addresses.map(address => addScoresToAddress(AddressResponseAddress.fromHybridAddress(address.hybridAddress), tokens, localityParams, elasticDenominator))
+    val scoredAddresses = addresses.zipWithIndex.map{case (address, index) => addScoresToAddress(index, AddressResponseAddress.fromHybridAddress(address.hybridAddress), tokens, localityParams, elasticDenominator)}
     val endingTime = System.currentTimeMillis()
     logger.trace("Hopper Score calucation time = "+(endingTime-startingTime)+" milliseconds")
     scoredAddresses
@@ -82,7 +82,7 @@ object HopperScoreHelper  {
     * @param tokens list of tokens handed down
     * @return new address response oobject with scores
     */
-  def addScoresToAddress(address: AddressResponseAddress,
+  def addScoresToAddress(addNo: Int,  address: AddressResponseAddress,
     tokens: Map[String, String],
     localityParams: Seq[(String,String)],elasticDenominator: Double): AddressResponseAddress = {
 
@@ -98,12 +98,6 @@ object HopperScoreHelper  {
     val saoStartSuffix = tokens.getOrElse(Tokens.saoStartSuffix, empty)
     val saoEndNumber = tokens.getOrElse(Tokens.saoEndNumber, empty)
     val saoEndSuffix = tokens.getOrElse(Tokens.saoEndSuffix, empty)
-    val streetName = tokens.getOrElse(Tokens.streetName, empty)
-    val locality = tokens.getOrElse(Tokens.locality, empty)
-    val townName = tokens.getOrElse(Tokens.townName, empty)
-    val postcode = tokens.getOrElse(Tokens.postcode, empty)
-    val postcodeIn = tokens.getOrElse(Tokens.postcodeIn, empty)
-    val postcodeOut = tokens.getOrElse(Tokens.postcodeOut, empty)
 
     val buildingScoreDebug = calculateBuildingScore(address,
       buildingName,
@@ -116,16 +110,8 @@ object HopperScoreHelper  {
 
     val buildingScore = Try(scoreMatrix(buildingScoreDebug).toDouble).getOrElse(0d)
 
-    val localityScoreDebug = calculateLocalityScore(
-      address,
-      postcode,
-      postcodeIn,
-      postcodeOut,
-      locality,
-      townName,
-      streetName,
-      organisationName,
-      buildingName)
+    //  extract locality score from values previously calculated for ambiguity calculation
+    val localityScoreDebug = localityParams.lift(addNo).getOrElse(("",""))._1
 
     val ambiguityPenalty = calculateAmbiguityPenalty(localityScoreDebug,localityParams)
 

--- a/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
@@ -536,7 +536,7 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
     val expected = mockAddressResponseAddressWithScores
 
     // When
-    val actual = HopperScoreHelper.addScoresToAddress(mockAddressResponseAddress,mockAddressTokens,mockLocalityParams,1D)
+    val actual = HopperScoreHelper.addScoresToAddress(0,mockAddressResponseAddress,mockAddressTokens,mockLocalityParams,1D)
 
     // Then
     actual shouldBe expected


### PR DESCRIPTION
Uses zipwithIndex to fetch previously calculated locality values