### PR TITLE
Fix for case of formatted address of hierarchy items

### DIFF
--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
@@ -29,7 +29,8 @@ class RelativesExpander @Inject ()(
 
   private def getFutExpandedSibling(apiKey: String, uprn: Long): Future[ExpandedSibling] =
     getFutAddressByUprn(apiKey, uprn).map {
-      (toMixedCase _).andThen(toExpandedSibling(uprn))
+      // withUnchangedCase to use case settings from API, toMixedCase to override
+      (withUnchangedCase _).andThen(toExpandedSibling(uprn))
     }
 
   private def getFutAddressByUprn(apiKey: String, uprn: Long): Future[AddressByUprnResponseContainer] = {
@@ -51,6 +52,11 @@ class RelativesExpander @Inject ()(
   private def toMixedCase(container: AddressByUprnResponseContainer): Option[String] =
     container.response.address.map { ara =>
       addressToMixedCase(ara.formattedAddress)
+    }
+
+  private def withUnchangedCase(container: AddressByUprnResponseContainer): Option[String] =
+    container.response.address.map { ara =>
+      ara.formattedAddress
     }
 
   private [utils] def addressToMixedCase(ucAddress: String): String = {

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpanderTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpanderTest.scala
@@ -26,9 +26,9 @@ class RelativesExpanderTest extends FlatSpec with Matchers with ScalaFutures {
     val rels = Seq(rel1,rel2)
 
     // Given
-    val esib1 = new ExpandedSibling(1,"7, Gate Reach, Exeter, EX2 9GA")
-    val esib2 = new ExpandedSibling(2,"7, Gate Reach, Exeter, EX2 9GA")
-    val esib3 = new ExpandedSibling(3,"7, Gate Reach, Exeter, EX2 9GA")
+    val esib1 = new ExpandedSibling(1,"7, GATE REACH, EXETER, EX2 9GA")
+    val esib2 = new ExpandedSibling(2,"7, GATE REACH, EXETER, EX2 9GA")
+    val esib3 = new ExpandedSibling(3,"7, GATE REACH, EXETER, EX2 9GA")
     val ex1 = new ExpandedRelative(1,Seq(esib1))
     val ex2 = new ExpandedRelative(2,Seq(esib2,esib3))
     val expectedSeq = Seq(ex1,ex2)

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander_NoApplicationTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander_NoApplicationTest.scala
@@ -23,9 +23,9 @@ class RelativesExpander_NoApplicationTest extends FlatSpec with Matchers with Mo
     val UprnOne = 123L
     val UprnTwo = 456L
     val UprnThree = 789L
-    val Address1 = "1, GATE REACH, EXETER, EX1 1GA"
-    val Address2 = "2, GATE REACH, EXETER, EX2 2GA"
-    val Address3 = "3, GATE REACH, EXETER, EX3 3GA"
+    val Address1 = "1, Gate Reach, Exeter, EX1 1GA"
+    val Address2 = "2, Gate Reach, Exeter, EX2 2GA"
+    val Address3 = "3, Gate Reach, Exeter, EX3 3GA"
 
     implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
     val addressIndexClient = mock[AddressIndexClient]


### PR DESCRIPTION
Change RelativesExpander class to use formattedAddress as is.