### PR TITLE
Restore Splunk logging (1497)

### DIFF
--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -27,8 +27,8 @@
     <logger name="addressIndex" level="INFO" />
     <logger name="application"  level="WARN" />
     <logger name="akka"         level="WARN" />
-    <logger name="SPLUNK"       level="WARN" />
-
+    <logger name="SPLUNK"       level="INFO" />
+    
     <logger name="com.avaje.ebean.config.PropertyMapLoader"            level="WARN" />
     <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
     <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />


### PR DESCRIPTION
We are intending to move the routine usage logging from the API (CF) to the Gateway but for now we still need this logging for our Splunk dashboard.