### PR TITLE
Scoring tidy - remove unnecessary calculations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,6 +164,7 @@ lazy val `address-index-server` = project.in(file("server"))
     PlayScala,
     PlayNettyServer,
     PlayAkkaHttpServer,
+    LauncherJarPlugin,
     SbtWeb,
     JavaAppPackaging,
     GitVersioning,

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -548,8 +548,6 @@ class AddressController @Inject()(
 
           val addresses: Seq[AddressResponseAddress] = hybridAddresses.map(AddressResponseAddress.fromHybridAddress)
 
-          val scoredAdresses = HopperScoreHelper.getScoresForAddresses(addresses, tokens, 1D)
-
           addresses.foreach { address =>
             writeSplunkLogs(formattedOutput = address.formattedAddressNag, numOfResults = total.toString, score = address.underlyingScore.toString)
           }
@@ -562,7 +560,7 @@ class AddressController @Inject()(
               dataVersion = dataVersion,
               response = AddressByPartialAddressResponse(
                 input = input,
-                addresses = scoredAdresses,
+                addresses = addresses,
                 filter = filterString,
                 historical = hist,
                 limit = limitInt,
@@ -695,8 +693,6 @@ class AddressController @Inject()(
 
           val addresses: Seq[AddressResponseAddress] = hybridAddresses.map(AddressResponseAddress.fromHybridAddress)
 
-          val scoredAdresses: Seq[AddressResponseAddress] = HopperScoreHelper.getScoresForAddresses(addresses, tokens, 1D)
-
           addresses.foreach { address =>
             writeSplunkLogs(formattedOutput = address.formattedAddressNag, numOfResults = total.toString, score = address.underlyingScore.toString)
           }
@@ -709,7 +705,7 @@ class AddressController @Inject()(
               dataVersion = dataVersion,
               response = AddressByPostcodeResponse(
                 postcode = postcode,
-                addresses = scoredAdresses,
+                addresses = addresses,
                 filter = filterString,
                 historical = hist,
                 limit = limitInt,

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -23,7 +23,7 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
-    <logger name="play"         level="WARN" />
+    <logger name="play"         level="INFO" />
     <logger name="addressIndex" level="INFO" />
     <logger name="application"  level="WARN" />
     <logger name="akka"         level="WARN" />

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -310,7 +310,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByPostcodeResponse(
           postcode = "some query",
-          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),Map.empty,1D),
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),
           filter = "",
           historical = true,
           limit = 100,


### PR DESCRIPTION
Removes nugatory bespoke score calculation from postcode and partial.

build.sbt change for windows runProd also included after testing