### PR TITLE
Change default number of users to 10 from 100

### DIFF
--- a/server/src/it/resources/uk/gov/ons/gatling/conf/_defaults.conf
+++ b/server/src/it/resources/uk/gov/ons/gatling/conf/_defaults.conf
@@ -1,7 +1,7 @@
 // Defaults for ALL requests to Address Index endpoints
 defaults {
   request_type = "GET"
-  concurrentUsers = 100
+  concurrentUsers = 10
   concurrentUsers = ${?CONCURRENT_USERS}
   baseUrl = "http://localhost:9001"
   baseUrl = ${?BASE_URL}


### PR DESCRIPTION
Lower the default value for `concurrenUsers` so that an endpoint is not mistakenly overloaded

