### PR TITLE
Updated documentation and minor fixes to configuration vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 * `re-start` utilise sbt-revolver, we have some eager singletons which load share objects
 * Go to web browser `localhost:9000`
 
+### How do I run performance tests ###
+
+See [Running Performance Tests](server/src/it/Running%20Performance%20Tests.md)
+
 ### Contribution guidelines ###
 
 * Scaladoc

--- a/server/src/it/Running Performance Tests.md
+++ b/server/src/it/Running Performance Tests.md
@@ -1,0 +1,122 @@
+Table of Contents
+=================
+
+* [About these Performance Tests](#about-these-performance-tests)
+* [Pre-requisites](#pre-requisites)
+    * [Setup target project(s) locally](#setup-target-projects-locally)
+        * [Setup address-index-api, address-index-demo-ui, address-index-data](#setup-address-index-api-address-index-demo-ui-address-index-data)
+    * [Setup Gatling](#setup-gatling)
+    * [OS Tuning](#os-tuning)
+        * [MacOS](#macos)
+        * [Windows (Blocked)](#windows-blocked)
+* [Usage](#usage)
+* [~~Running gatling tests from a docker container~~](#running-gatling-tests-from-a-docker-container)
+* [Configuration](#configuration)
+* [License](#license)
+
+
+# About these Performance Tests
+
+This project contains a suite of Gatling based performance tests targeted at endpoints for address-index-api Server.
+Endpoint specific configuration has been included in this project and contains for example, specific parameter value for an endpoint.
+
+Additionally, a generic get request option is also available which allows performance testing of any GET request endpoint.
+
+Note that, this suite of tests can easily overload an endpoint to the extent that the server crashes.
+Please ensure that you have the permission(s) and agreements in place before you execute this load test with a high number of RPS (requests per second).
+
+# Pre-requisites
+
+## Setup target project(s) locally
+
+It is assumed that you have setup address-index-api server locally OR have an endpoint which you are allowed to load.
+See below for links to this setup documentation.
+
+### Setup address-index-api, address-index-demo-ui, address-index-data
+
+Head over to the [following](https://collaborate2.ons.gov.uk/confluence/display/RAI/Setting+up+Address+Index+Server+and+UI+with+local+ElasticSearch) page on Confluence.
+
+## Setup Gatling
+
+Since this project uses Gatling's SBT plugin, all that is needed is to be able to use SBT.
+As a part of setting up [address-index-api](#setup-address-index-api-address-index-demo-ui-address-index-data), you will have all the pre-requisites in place to run the gatling simulations in this project.
+
+## OS Tuning
+
+In order to subject any kind of meaningful load, OS tuning must be done in order to raise or un-restrict resource consumption limits imposed by consumer oriented OSes.
+
+### MacOS
+
+On macOS, the constraints most relevant to Gatling load tests include:
+
+1. The maximum number of open files (`sysctl kern.maxfiles` )
+1. The maximum number of open files per process (`sysctl kern.maxfilesperproc` )
+1. The maximum number of open processes
+1. The maximum number of open ports ('ephemeral port limit')
+1. The maximum time before a TCP socket can be re-used
+
+Instructions on altering all of the above limits is detailed in [macOS Tuning for Gatling](macOS%20Tuning%20for%20Gatling.md)
+
+### Windows (Blocked)
+
+A similar exercise from a Windows on-network machine would require elevated privileges since most required operations would require admin access (assuming that removes other security restrictions such as being able to edit the Windows registry).
+At the time of this writing, it has not been possible to obtain either a Windows machine (off-network, admin access) OR admin access on the on-network Window laptop.
+It is worth bearing in mind that the machine from which the Gatling tests are run must be capable of supporting running load tests of high RPS.
+
+# Usage
+
+The gatling simulations are executed using the official gatling SBT plugin. The parameters need to be passed in as `JAVA_OPTS`:
+
+| Parameter Name            | Description                                                                  | Default Value       | Comments/Notes                                                        |
+|:--------------------------|:-----------------------------------------------------------------------------|:--------------------|:----------------------------------------------------------------------|
+| REQUESTS_PER_SECOND (RPS) | (Optional) Number of requests per second                                     | 10                  |                                                                       |
+| BASE_URL                  | (Mandatory) Complete URL of endpoint with param  OR, `host:port of endpoint` | --                  | Need to be the complete url if CONFIG_NAME is **not** being specified |
+| CONFIG_NAME               | (Optional) Name of the key in the configuration files `src/it/resources`     | generic_get_request |                                                                       |
+
+
+The simplest first run would be run the suite of tests against a generic GET endpoint:
+```shell
+JAVA_OPTS="-DBASE_URL=https://host:port/getsomeresource?param1=value1&param2=value2" sbt "project address-index-server" "gatling-it:test" "gatling-it:lastReport"
+```
+Note that, since CONFIG_NAME was not passed in, the complete URL, with all parameters, must be passed in. The above uses a default RPS of 10.
+Once the test is completed, the report will be opened in the default browser (thanks to `gatling-it:lastReport`).
+
+To simply run *all* the simulation(s):
+`JAVA_OPTS="-DCONFIG_NAME=ai-api-addresses-mock-data -DREQUESTS_PER_SECOND=101" sbt "gatling-it:test" "gatling-it:lastReport"`
+this will run the gatling test against an endpoint defined under the key `ai-api-addresses-mock-data` in one of the configuration files under `src/it/resources` directory.
+
+Customize the endpoint by using the `BASE_URL` property like so:
+`JAVA_OPTS="-DCONFIG_NAME=ai-api-addresses-mock-data -DREQUESTS_PER_SECOND=1000 -DBASE_URL=http://localhost:9000" sbt "gatling-it:test" "gatling-it:lastReport"`
+
+To run a specific simulation:
+`JAVA_OPTS="-DCONFIG_NAME=ai-api-addresses-mock-data -DREQUESTS_PER_SECOND=101" sbt "gatling-it:testOnly uk.gov.ons.gatling.simulations.RegistersSimulation" "gatling-it:lastReport"`
+
+A useful example is as follows, where the number of users is passed in, a specific config file is used and at the end of the simulation the reports is automatically opened:
+`JAVA_OPTS="-DREQUESTS_PER_SECOND=100 -DCONFIG_NAME=ai-api-pcs-exeter" sbt "gatling-it:test" "gatling-it:lastReport"`
+(The above runs the gatling simulation using the configuration under the ai-api-pcs-exeter key in the conf files in `src/it/resources` and assumes that the AI server is running locally, for example, like so:
+```shell
+JAVA_OPTS="-Xms2g -Xmx2g -DONS_AI_API_ES_PORT=9200 -DONS_AI_API_ES_URI=localhost -DONS_AI_API_HYBRID_INDEX_HIST=hybrid-historical_811_111017_1530276985432" \
+sbt "project address-index-server" "run 9001"
+```
+The above runs the AI server and configures it to use ElasticSearch running at `localhost:9200` with index name specified by ONS_AI_API_HYBRID_INDEX_HIST property.
+)
+
+# ~~Running gatling tests from a docker container~~
+
+This is work in progress.
+
+Execute the following command:
+
+```shell
+docker run --rm -it -v /Users/ashjindal/ons/gatling/registers-performance-tests:/usr/perftest-workdir --env JAVA_OPTS="-DCONFIG_NAME=ai-api-simple-pcs -DREQUESTS_PER_SECOND=2000 -DBASE_URL=http://host.docker.internal:9001"  onsdigital/jenkins-slave-sbt
+```
+
+# Configuration
+
+The list of configurable properties is visible in the `.conf` files in `src/test/resources/uk/gov/ons/conf/gatling/conf/`
+
+# License
+
+Copyright © 2017, [Office for National Statistics](https://www.ons.gov.uk)
+
+Released under MIT license, see [LICENSE](LICENSE) for details.

--- a/server/src/it/macOS Tuning for Gatling.md
+++ b/server/src/it/macOS Tuning for Gatling.md
@@ -1,0 +1,204 @@
+Table of Contents
+=================
+
+
+<!-- vim-markdown-toc GFM -->
+
+* [Problem 1: How to Change Open Files and Maximum Processes limits on MacOS](#problem-1-how-to-change-open-files-and-maximum-processes-limits-on-macos)
+    * [What does NOT work](#what-does-not-work)
+    * [What DOES work](#what-does-work)
+        * [To check the current limits on your Mac OS X system, run:](#to-check-the-current-limits-on-your-mac-os-x-system-run)
+        * [Adjusting Open File Limits](#adjusting-open-file-limits)
+* [Problem 2: Changing the Ephemeral Port Limit](#problem-2-changing-the-ephemeral-port-limit)
+
+<!-- vim-markdown-toc -->
+
+# Problem 1: How to Change Open Files and Maximum Processes limits on MacOS
+By default the number of file descriptors that a process is allowed to open and the number of processes a user is allowed to open is restricted.
+These limits can be seen by using the commands `ulimit -Ha`  (for Hard Limits) and `ulimit -Sa` for Soft Limits.
+
+[This](https://unix.stackexchange.com/questions/108174/how-to-persistently-control-maximum-system-resource-consumption-on-mac) is a good writeup that explains the meaning of the 'Hard' and 'Soft' limits.
+
+The aim of this guide is to detail the macOS tuning needed in order to run a Gatling test with a useful load profile.
+These instructions are only meant to enable the execution of gatling based load test simulations to be run on a dev machine.
+Without these settings when running Gatling tests, you might see issues such as 'Caused by: java.net.SocketException: Too many open files' which will be interpreted falsely by Gatling as failed tests even though there may not be a problem with the application itself.
+
+## What does NOT work
+When you attempt to fine tune macOS for Gatling, you may be led down a number of paths which don't have any effect on the relevant system parameters.
+In order to prevent you from wasting time on these red herrings, here is a list of things that I found ++**did not work**++:
+
+1. Using ﻿`-XX:-MaxFDLimit` JVM Arg either via
+* The `.sbtopts` file in the root of the project with the following contents:
+```shell
+-J-Xmx3536M
+-J-Xss1M
+-J-XX:+CMSClassUnloadingEnabled
+-J-XX:+UseConcMarkSweepGC
+-J-XX:MaxPermSize=724M
+-J-XX:-MaxFDLimit
+```
+
+* Attempting to pass in `-XX:-MaxFDLimit` via the sbt build:
+
+```scala
+javaOptions in Gatling := overrideDefaultJavaOptions("-XX:-MaxFDLimit")
+```
+
+* Attempting to use `-XX:-MaxFDLimit` as a default JVM option in the hope that it gets picked up.
+
+The problem with all of the above approaches is not that `-XX:-MaxFDLimit` is not picked up, but that it has no effect whatsoever.
+
+
+2. In a non-root session, attempting to set the ulimit values for maximum number of allowed processes (`ulimit -h`) or  maximum number of open file descriptors (`ulimit -n`) does not work. These values *can* be changed by the root user, but then the gatling test would have to be run as the root user as well.
+
+
+## What DOES work
+
+### To check the current limits on your Mac OS X system, run:
+
+```shell
+launchctl limit maxfiles
+```
+
+The last two columns are the soft and hard limits, respectively.
+
+### Adjusting Open File Limits
+
+To adjust open files limits on a system-wide basis, you must create **two** configuration files. The first is a property list (aka plist) file in `/Library/LaunchDaemons/limit.maxfiles.plist` that contains the following XML configuration:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+    <dict>
+      <key>Label</key>
+        <string>limit.maxfiles</string>
+      <key>ProgramArguments</key>
+        <array>
+          <string>launchctl</string>
+          <string>limit</string>
+          <string>maxfiles</string>
+          <string>1048576</string>
+          <string>1048600</string>
+        </array>
+      <key>RunAtLoad</key>
+        <true/>
+      <key>ServiceIPC</key>
+        <false/>
+    </dict>
+  </plist>
+```
+
+This will set the open files limit to 200000. The second plist configuration file should be stored in `/Library/LaunchDaemons/limit.maxproc.plist` with the following contents:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+    <dict>
+      <key>Label</key>
+        <string>limit.maxproc</string>
+      <key>ProgramArguments</key>
+        <array>
+          <string>launchctl</string>
+          <string>limit</string>
+          <string>maxproc</string>
+          <string>2048</string>
+          <string>2048</string>
+        </array>
+      <key>RunAtLoad</key>
+        <true />
+      <key>ServiceIPC</key>
+        <false />
+    </dict>
+  </plist>
+```
+
+Both plist files must be owned by root:wheel and have permissions -rw-r--r--. This permissions should be in place by default, but you can ensure that they are in place by running sudo chmod 644 <filename>. While the steps explained above will cause system-wide open file limits to be correctly set upon restart, you can apply them manually by running launchctl limit.
+
+
+The above plists are attached to this project. You can execute the following commands to do the needful:
+
+```shell
+sudo mv limit.maxfiles.plist /Library/LaunchDaemons
+sudo mv limit.maxproc.plist /Library/LaunchDaemons
+
+sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+sudo chown root:wheel /Library/LaunchDaemons/limit.maxproc.plist
+
+sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+sudo launchctl load -w /Library/LaunchDaemons/limit.maxproc.plist
+```
+
+Finally, **remember to reboot your machine!**
+
+But, we are not done yet !
+
+# Problem 2: Changing the Ephemeral Port Limit
+
+The next problem encountered is due to the limited number of ports available to create connections on as well as the time that is required to elapse before a once-used port becomes available to be used again.
+
+This limit is visible by using the following:
+
+```shell
+$ sysctl net.inet.ip.portrange.first net.inet.ip.portrange.last
+net.inet.ip.portrange.first: 49152
+net.inet.ip.portrange.last: 65535
+```
+
+Additionally, once a port has been used, [TIME_WAIT](http://www.softlab.ntua.gr/facilities/documentation/unix/unix-socket-faq/unix-socket-faq-2.html#ss2.7)
+must elapse before it can be reused again. This duration is 15 secons on macOS
+
+```shell
+$ sysctl net.inet.tcp.msl
+net.inet.tcp.msl: 15000
+```
+
+To change the avaiable number of ports and to allow a port to become reusable quicker, the following can be done:
+
+1.  Increase the available port range:
+```shell
+$ sudo sysctl -w net.inet.ip.portrange.first=32768
+  Password:
+  net.inet.ip.portrange.first: 49152 -> 32768
+```
+
+2. Reduce the TIME_WAIT:
+```shell
+   $ sudo sysctl -w net.inet.tcp.msl=1000
+   net.inet.tcp.msl: 15000 -> 1000
+```
+
+On one machine, after making all of the above settings, the failure rate went down from around 50% to 0%:
+
+```shell
+---- Response Time Distribution ------------------------------------------------
+> t < 800 ms                                         48138 ( 48%)
+> 800 ms < t < 1200 ms                                   1 (  0%)
+> t > 1200 ms                                            0 (  0%)
+> failed                                             51861 ( 52%)
+---- Errors --------------------------------------------------------------------
+> j.n.ConnectException: Can't assign requested address: localhos  51794 (99.87%)
+t/127.0.0.1:9000
+> status.find.in(200,304,201,202,203,204,205,206,207,208,209), b     67 ( 0.13%)
+ut actually found 500
+================================================================================
+```
+
+```shell
+---- Response Time Distribution ------------------------------------------------
+> t < 800 ms                                        100000 (100%)
+> 800 ms < t < 1200 ms                                   0 (  0%)
+> t > 1200 ms                                            0 (  0%)
+> failed                                                 0 (  0%)
+================================================================================
+```
+
+Note that the above sysctl changes only last for the shell they are executed in and will not be propagated to a new shell or after an OS restart.
+They can be preserved by adding them to /etc/sysctl.conf :
+
+```
+$ cat /etc/sysctl.conf
+net.inet.ip.portrange.first=32768
+net.inet.tcp.msl=1000
+```

--- a/server/src/it/resources/uk/gov/ons/gatling/conf/_defaults.conf
+++ b/server/src/it/resources/uk/gov/ons/gatling/conf/_defaults.conf
@@ -1,8 +1,8 @@
 // Defaults for ALL requests to Address Index endpoints
 defaults {
   request_type = "GET"
-  concurrentUsers = 10
-  concurrentUsers = ${?CONCURRENT_USERS}
+  requestsPerSecond = 10
+  requestsPerSecond = ${?REQUESTS_PER_SECOND}
   baseUrl = "http://localhost:9001"
   baseUrl = ${?BASE_URL}
 }

--- a/server/src/it/scala/uk/gov/ons/gatling/conf/ConfigLoader.scala
+++ b/server/src/it/scala/uk/gov/ons/gatling/conf/ConfigLoader.scala
@@ -13,7 +13,7 @@ object ConfigLoader {
     .withFallback(applicationConfig)
     .resolve()
 
-  lazy val apiSpecificConfigName: String = System.getProperty("configName", "generic_get_request")
+  lazy val apiSpecificConfigName: String = System.getProperty("CONFIG_NAME", "generic_get_request")
 
   def apply(configurationKey: String): String = config.getString(apiSpecificConfigName + "." + configurationKey)
   def getPOSTRequestBodyJSONPath() = "%s%s%s".format(PathPrefix, apiSpecificConfigName, ".json")

--- a/server/src/it/scala/uk/gov/ons/gatling/simulations/RegistersSimulation.scala
+++ b/server/src/it/scala/uk/gov/ons/gatling/simulations/RegistersSimulation.scala
@@ -12,12 +12,12 @@ import scala.language.postfixOps
 class RegistersSimulation extends Simulation {
 
   val baseUrl: String = ConfigLoader("baseUrl")
-  val numOfConcurrentUsers: Int = ConfigLoader("concurrentUsers") toInt
+  val numOfRequestsPerSecond: Int = ConfigLoader("requestsPerSecond") toInt
   val requestRelPath = ConfigLoader("request_rel_path")
   val requestType = ConfigLoader("request_type")
   val requestName: String = ConfigLoader("request_name_prefix").stripSuffix(" ") + ": " + baseUrl + requestRelPath
 
-  println(s"Running test with numOfConcurrentUsers: $numOfConcurrentUsers, baseUrl : $baseUrl, $requestType Request : $requestRelPath")
+  println(s"Running test with numOfRequestsPerSecond: $numOfRequestsPerSecond, baseUrl : $baseUrl, $requestType Request : $requestRelPath")
 
   val httpProtocol: HttpProtocolBuilder = http
     .baseURL(baseUrl)
@@ -47,8 +47,8 @@ class RegistersSimulation extends Simulation {
     scenario(requestName).exec(httpRequestBuilder)
   }
 
-  setUp(scn.inject(constantUsersPerSec(numOfConcurrentUsers) during (1 minute)))
-    .throttle(jumpToRps(numOfConcurrentUsers), holdFor(1 minute))
+  setUp(scn.inject(constantUsersPerSec(numOfRequestsPerSecond) during (1 minute)))
+    .throttle(jumpToRps(numOfRequestsPerSecond), holdFor(1 minute))
     .protocols(httpProtocol)
 
 }


### PR DESCRIPTION
Renamed numOfConcurrentUsers to numOfRequestsPerSecond since from the
perspective of an end-user, that is what this number represents (From
the point of view of the actual gatling simulation itself, this param is
used for both number of concurrent users as well as concurret requests
per second)

Renamed configName to CONFIG_NAME to align with the other system
properties that the gatling tests accept.