### PR TITLE
Override universalBin task for server to include parser resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import com.iheart.sbtPlaySwagger.SwaggerPlugin.autoImport.swaggerDomainNameSpaces
 import com.typesafe.sbt.SbtNativePackager.autoImport.NativePackagerHelper._
+import com.typesafe.sbt.packager.universal.ZipHelper
 import com.typesafe.sbt.web.SbtWeb
 import play.sbt.PlayScala
 import play.sbt.routes.RoutesKeys._
-import sbt.Keys._
+import sbt.Keys.{mappings, _}
 import sbt.Resolver.{file => _, url => _}
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
@@ -33,6 +34,16 @@ lazy val assemblySettings: Seq[Def.Setting[_]] = Seq(
     case x =>
       val oldStrategy = (assemblyMergeStrategy in assembly).value
       oldStrategy(x)
+  }
+)
+
+lazy val serverUniversalMappings: Seq[Def.Setting[_]] = Seq(
+  // The following will cause parsers/.../resources directory to be added to the list of mappings recursively
+  // excluding .md and .conf files
+  mappings in Universal ++= {
+    val rootDir = (baseDirectory.value).getParentFile
+    def directoryToAdd = (rootDir / "parsers/src/main/resources")
+    ((directoryToAdd.***) * ("*" -- ("*.md" || "*.conf"))) pair relativeTo(rootDir)
   }
 )
 
@@ -147,6 +158,7 @@ lazy val `address-index-client` = project.in(file("client"))
 
 lazy val `address-index-server` = project.in(file("server"))
   .settings(localCommonSettings: _*)
+  .settings(serverUniversalMappings: _*)
   .settings(
     libraryDependencies ++= serverDeps,
     routesGenerator := InjectedRoutesGenerator,
@@ -154,6 +166,50 @@ lazy val `address-index-server` = project.in(file("server"))
     Revolver.settings ++ Seq(
       mainClass in reStart := Some("play.core.server.ProdServerStart")
     ),
+    packageBin in Universal := {
+      // Get the name of the package being built
+      val originalFileName = (packageBin in Universal).value
+
+      // Create a new temp file name.
+      val (base, ext) = originalFileName.baseAndExt
+      val newFileName = file(originalFileName.getParent) / (base + "_dist." + ext)
+
+      // Unzip the zip archive created
+      val extractedFiles = IO.unzip(originalFileName, file(originalFileName.getParent))
+
+      // Move any files in "parsers" directory to root
+      val mappings: Set[(File, String)] = extractedFiles.map(f => {
+        val relativePathWithoutRootDir = f.getAbsolutePath.substring(originalFileName.getParent.size + base.size + 2)
+        val relativePathWithRootDir = f.getAbsolutePath.substring(originalFileName.getParent.size + 1)
+
+        val justFileName = f.getName
+
+        // if path of file starts with parsers, then add to root of zip
+        if (relativePathWithoutRootDir.startsWith("parsers")) {
+          val (base, ext) = f.baseAndExt
+          (f, justFileName)
+        } else {
+          (f, relativePathWithRootDir)
+        }
+      })
+
+      // Set files under bin as executable just as the universalBin task does
+      val binFiles = mappings.filter { case (file, path) => path.startsWith("bin/") }
+      for (f <- binFiles) f._1.setExecutable(true)
+
+      // Zip the files up and rename to the original zip name
+      ZipHelper.zip(mappings, newFileName)
+      IO.move(newFileName, originalFileName)
+
+      // Create a copy of the original distribution to have a predictable name used by Jenkins jobs to
+      // push application bundle to Cloud Foundry
+      IO.copyFile(originalFileName, file(originalFileName.getParent) / s"${name.value}.zip")
+
+      // Delete temporary directory
+      IO.delete(file(originalFileName.getParent + "/" + originalFileName.base))
+
+      originalFileName
+    },
     resourceGenerators in Compile += Def.task {
       val file = (resourceManaged in Compile).value / "version.app"
       val contents = git.gitHeadCommit.value.map{ sha => s"v_$sha" }.getOrElse("develop")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"           % "2.6.10" exclude("org.slf4j", "slf4j-simple"))
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"         % "0.14.3")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"  % "1.1.4")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"  % "1.3.3")
 addSbtPlugin("ch.jodersky"       % "sbt-jni"              % "1.2.4")
 addSbtPlugin("io.spray"          % "sbt-revolver"         % "0.8.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"              % "0.9.0")


### PR DESCRIPTION
This change allows the removal of all the 'shell' steps needed after
construction of the zip package via SBT. These manual steps include:
    1. Modifying the zip using 'jar uf' to add parser resources (details
below)
    2. Creating a copy of the zip to allow using a predicatable name for
the Jenkins Cloud Foundry plugin to push the app bundle.

Removing the need for the shell steps will make this build more portable
and easily reproducible.

Note that this required upgrading sbt-native-packager from v.1.1.4 to
v1.3.3

Before the server (address-index-api/server) can be deployed to Cloud
Foundry, a zip package is created using:
 $ sbt "project address-index-server" "universal:packageBin"

and the zip modified by using a command like so:
    $ jar uf server/target/universal/address-index-server.zip \
     -C parsers/src/main/resources libcrftagger-linux.so \
     -C parsers/src/main/resources addressCRFA.crfsuite \
     -C parsers/src/main/resources/input_pre_post_processing business \
     -C parsers/src/main/resources/input_pre_post_processing company \
     -C parsers/src/main/resources/input_pre_post_processing county \
     .....

Ideally, it is desired that all steps required to create a distribution
be done entirely by the build tool, otherwise these steps would have to
be replicated every time a package has to be made (either by devs or by
Jenkins).