### PR TITLE
Introduce verbose parameter for all endpoints (1686)

### DIFF
--- a/client/src/test/scala/uk/gov/ons/addressIndex/client/AddressIndexClientTest.scala
+++ b/client/src/test/scala/uk/gov/ons/addressIndex/client/AddressIndexClientTest.scala
@@ -35,7 +35,8 @@ class AddressIndexClientTest extends FlatSpec with Matchers {
         id = UUID.randomUUID,
         apiKey = "",
         startdate = "",
-        enddate = ""
+        enddate = "",
+        verbose = true
       )
     ).url
     val expected = s"${apiHost}/addresses/uprn/101010"
@@ -66,7 +67,8 @@ class AddressIndexClientTest extends FlatSpec with Matchers {
         id = UUID.randomUUID,
         limit = "10",
         offset = "0",
-        apiKey = ""
+        apiKey = "",
+        verbose = true
       )
     ).queryString
     val expected = Map(

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
@@ -200,7 +200,8 @@ class ClericalToolController @Inject()(
             lon = "-3.5091076",
             offset = offset,
             id = UUID.randomUUID,
-            apiKey = apiKey
+            apiKey = apiKey,
+            verbose = true
           )
         ) map { resp: AddressBySearchResponseContainer =>
           val filledForm = SingleMatchController.form.fill(SingleSearchForm(addressText, filterText, historicalValue, matchthresholdValue, startDateVal, endDateVal))
@@ -339,7 +340,8 @@ class ClericalToolController @Inject()(
           apiKey = apiKey,
           historical = historicalValue,
           startdate = startDateVal,
-          enddate = endDateVal
+          enddate = endDateVal,
+          verbose = true
         )
       ) map { resp: AddressByUprnResponseContainer =>
         val filledForm = SingleMatchController.form.fill(SingleSearchForm(input.toString, filter.getOrElse(""), historicalValue, matchthresholdValue, startDateVal, endDateVal))
@@ -398,7 +400,8 @@ class ClericalToolController @Inject()(
           apiKey = apiKey,
           historical = historicalValue,
           startdate = startDateVal,
-          enddate = endDateVal
+          enddate = endDateVal,
+          verbose = true
         )
       ) flatMap { resp: AddressByUprnResponseContainer =>
         val filledForm = SingleMatchController.form.fill(SingleSearchForm(input.toString,"", historicalValue, matchthresholdValue, startDateVal, endDateVal))
@@ -551,7 +554,8 @@ class ClericalToolController @Inject()(
               lon = "-3.5091076",
               offset = offset,
               id = UUID.randomUUID,
-              apiKey = apiKey
+              apiKey = apiKey,
+              verbose = true
             )
           ) map { resp: AddressBySearchResponseContainer =>
             val filledForm = SingleMatchController.form.fill(SingleSearchForm(addressText, filterText, historicalValue, matchthresholdValue, startDateVal, endDateVal))

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/ClericalToolController.scala
@@ -412,7 +412,7 @@ class ClericalToolController @Inject()(
           else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
 
         val rels = resp.response.address.map(_.relatives)
-        val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.getOrElse(Seq())).recover {
+        val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.get.getOrElse(Seq())).recover {
           case _: Throwable => Seq()
         }
 

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/PostcodeController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/PostcodeController.scala
@@ -163,7 +163,8 @@ class PostcodeController @Inject()(
             limit = limit,
             offset = offset,
             id = UUID.randomUUID,
-            apiKey = apiKey
+            apiKey = apiKey,
+            verbose = true
           )
         } map { resp: AddressByPostcodeResponseContainer =>
           val filledForm = PostcodeController.form.fill(PostcodeSearchForm(addressText,filterText, historicalValue, startDateVal, endDateVal))

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/RadiusController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/RadiusController.scala
@@ -188,7 +188,8 @@ class RadiusController @Inject()(
             lat = latString,
             lon = lonString,
             id = UUID.randomUUID,
-            apiKey = apiKey
+            apiKey = apiKey,
+            verbose = true
           )
         ) map { resp: AddressBySearchResponseContainer =>
           val filledForm = RadiusController.form.fill(RadiusSearchForm(addressText,filterText,rangeString,latString,lonString, historicalValue, startDateVal, endDateVal))

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
@@ -371,11 +371,9 @@ class SingleMatchController @Inject()(
             else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
 
           val rels = resp.response.address.map(_.relatives)
-          val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.getOrElse(Seq())).recover {
-         //   case _: Throwable => {
+          val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.get.getOrElse(Seq())).recover {
               case exception => {
                 logger.warn("relatives failed" + exception)
-       //     }
               Seq()}
           }
 
@@ -465,7 +463,7 @@ class SingleMatchController @Inject()(
             else Some(s"${resp.status.code} ${resp.status.message} : ${resp.errors.headOption.map(_.message).getOrElse("")}")
 
           val rels = resp.response.address.map(_.relatives)
-          val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.getOrElse(Seq())).recover {
+          val futExpandedRels = relativesExpander.futExpandRelatives(apiKey, rels.get.getOrElse(Seq())).recover {
             case _: Throwable => Seq()
           }
 

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/controllers/SingleMatchController.scala
@@ -192,6 +192,7 @@ class SingleMatchController @Inject()(
             rangekm = rangeString,
             lat = latString,
             lon = lonString,
+            verbose = true,
             id = UUID.randomUUID,
             apiKey = apiKey
           )
@@ -274,9 +275,10 @@ class SingleMatchController @Inject()(
           uprn = numericUPRN,
           id = UUID.randomUUID,
           historical = historicalValue,
-            apiKey = apiKey,
+          apiKey = apiKey,
           startdate = startDateVal,
-          enddate = endDateVal
+          enddate = endDateVal,
+          verbose = true
         )
       ) map { resp: AddressByUprnResponseContainer =>
         val filledForm = SingleMatchController.form.fill(SingleSearchForm(addressText,filterText, historicalValue, matchthresholdValue, startDateVal, endDateVal))
@@ -357,7 +359,8 @@ class SingleMatchController @Inject()(
             historical = historicalValue,
             apiKey = apiKey,
             startdate = startDateVal,
-            enddate = endDateVal
+            enddate = endDateVal,
+            verbose = true
           )
         ) flatMap { resp: AddressByUprnResponseContainer =>
           val filledForm = SingleMatchController.form.fill(SingleSearchForm(addressText,filterText, historicalValue,matchthresholdValue, startDateVal, endDateVal))
@@ -449,7 +452,8 @@ class SingleMatchController @Inject()(
             historical = historical,
             apiKey = apiKey,
             startdate = startDateVal,
-            enddate = endDateVal
+            enddate = endDateVal,
+            verbose = true
           )
         ) flatMap { resp: AddressByUprnResponseContainer =>
           val filledForm = SingleMatchController.form.fill(SingleSearchForm(addressText,filterText, historical, matchthresholdValue, startDateVal, endDateVal))

--- a/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
+++ b/demo-ui/app/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander.scala
@@ -44,7 +44,8 @@ class RelativesExpander @Inject ()(
         historical = true,
         apiKey = apiKey,
         startdate = "",
-        enddate = ""
+        enddate = "",
+        verbose = false
       )
     )
   }

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
@@ -191,8 +191,8 @@ object AddressIndexClientMock {
   val mockAddressResponseAddress = AddressResponseAddress(
     uprn = "",
     parentUprn = "",
-    relatives = Seq(mockRelativeResponse),
-    crossRefs = Seq(mockCrossRefResponse),
+    relatives = Some(Seq(mockRelativeResponse)),
+    crossRefs = Some(Seq(mockCrossRefResponse)),
     formattedAddress = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressNag = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressPaf = "7, GATE REACH, EXETER, EX2 9GA",

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/client/AddressIndexClientMock.scala
@@ -45,7 +45,8 @@ class AddressIndexClientMock @Inject()(override val client : WSClient,
     total = 1,
     sampleSize = 20,
     maxScore = 1f,
-    matchthreshold = 5f
+    matchthreshold = 5f,
+    verbose = true
   )
 
   val mockAddressByPostcodeResponse = AddressByPostcodeResponse (
@@ -58,7 +59,8 @@ class AddressIndexClientMock @Inject()(override val client : WSClient,
     total = 1,
     maxScore = 1f,
     startDate = "",
-    endDate = ""
+    endDate = "",
+    verbose = false
   )
 
   val mockSearchResponseContainer = AddressBySearchResponseContainer (
@@ -207,7 +209,9 @@ object AddressIndexClientMock {
 
   val mockAddressByUprnResponse = AddressByUprnResponse (
     address = Some(mockAddressResponseAddress: AddressResponseAddress),
+    historical = true,
     startDate = "",
-    endDate = ""
+    endDate = "",
+    verbose = true
   )
 }

--- a/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander_NoApplicationTest.scala
+++ b/demo-ui/test/uk/gov/ons/addressIndex/demoui/utils/RelativesExpander_NoApplicationTest.scala
@@ -38,7 +38,7 @@ class RelativesExpander_NoApplicationTest extends FlatSpec with Matchers with Mo
       AddressByUprnResponseContainer(
         "api-version",
         "data-version",
-        response = AddressByUprnResponse(addressResponseAddressOpt, "", ""),
+        response = AddressByUprnResponse(addressResponseAddressOpt,true, "", "",true),
         status = mockAddressResponseStatus,
         errors = Seq.empty)
     }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -12,6 +12,7 @@ case class AddressIndexUPRNRequest(
   historical: Boolean,
   startdate: String,
   enddate: String,
+  verbose: Boolean
 )
 
 case class AddressIndexSearchRequest(
@@ -26,6 +27,7 @@ case class AddressIndexSearchRequest(
   lon: String,
   limit: String,
   offset: String,
+  verbose: Boolean,
   id: UUID,
   apiKey: String
 )
@@ -38,6 +40,7 @@ case class AddressIndexPostcodeRequest(
   enddate: String,
   limit: String,
   offset: String,
+  verbose: Boolean,
   id: UUID,
   apiKey: String
 )

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressBySearchResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressBySearchResponse.scala
@@ -26,7 +26,8 @@ case class AddressBySearchResponse(
   total: Long,
   sampleSize: Long,
   maxScore: Double,
-  matchthreshold: Float
+  matchthreshold: Float,
+  verbose: Boolean
 )
 
 object AddressBySearchResponse {

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddress.scala
@@ -38,7 +38,7 @@ object AddressResponseAddress {
     * @param other HybridAddress from ES
     * @return
     */
-  def fromHybridAddress(other: HybridAddress): AddressResponseAddress = {
+  def fromHybridAddress(other: HybridAddress, verbose: Boolean): AddressResponseAddress = {
 
     val chosenNag: Option[NationalAddressGazetteerAddress] = chooseMostRecentNag(other.lpi, NationalAddressGazetteerAddress.Languages.english)
     val formattedAddressNag = if (chosenNag.isEmpty) "" else chosenNag.get.mixedNag
@@ -53,17 +53,17 @@ object AddressResponseAddress {
     AddressResponseAddress(
       uprn = other.uprn,
       parentUprn = other.parentUprn,
-      relatives = Some(other.relatives.map(AddressResponseRelative.fromRelative)),
-      crossRefs = Some(other.crossRefs.map(AddressResponseCrossRef.fromCrossRef)),
+      relatives = {if (verbose) Some(other.relatives.map(AddressResponseRelative.fromRelative)) else None},
+      crossRefs = {if (verbose) Some(other.crossRefs.map(AddressResponseCrossRef.fromCrossRef)) else None},
       formattedAddress = formattedAddressNag,
       formattedAddressNag = formattedAddressNag,
       formattedAddressPaf = formattedAddressPaf,
       welshFormattedAddressNag = welshFormattedAddressNag,
       welshFormattedAddressPaf = welshFormattedAddressPaf,
-      paf = chosenPaf.map(AddressResponsePaf.fromPafAddress),
-      nag = chosenNag.map(AddressResponseNag.fromNagAddress),
+      paf = {if (verbose) chosenPaf.map(AddressResponsePaf.fromPafAddress) else None},
+      nag = {if (verbose) chosenNag.map(AddressResponseNag.fromNagAddress) else None},
       geo = chosenNag.flatMap(AddressResponseGeo.fromNagAddress),
-      confidenceScore = other.score,
+      confidenceScore = 1D,
       underlyingScore = other.score
     )
   }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddress.scala
@@ -16,8 +16,8 @@ import uk.gov.ons.addressIndex.model.db.index.{HybridAddress, NationalAddressGaz
 case class AddressResponseAddress(
   uprn: String,
   parentUprn: String,
-  relatives: Seq[AddressResponseRelative],
-  crossRefs: Seq[AddressResponseCrossRef],
+  relatives: Option[Seq[AddressResponseRelative]],
+  crossRefs: Option[Seq[AddressResponseCrossRef]],
   formattedAddress: String,
   formattedAddressNag: String,
   formattedAddressPaf: String,
@@ -53,8 +53,8 @@ object AddressResponseAddress {
     AddressResponseAddress(
       uprn = other.uprn,
       parentUprn = other.parentUprn,
-      relatives = other.relatives.map(AddressResponseRelative.fromRelative),
-      crossRefs = other.crossRefs.map(AddressResponseCrossRef.fromCrossRef),
+      relatives = Some(other.relatives.map(AddressResponseRelative.fromRelative)),
+      crossRefs = Some(other.crossRefs.map(AddressResponseCrossRef.fromCrossRef)),
       formattedAddress = formattedAddressNag,
       formattedAddressNag = formattedAddressNag,
       formattedAddressPaf = formattedAddressPaf,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/partialaddress/AddressByPartialAddressResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/partialaddress/AddressByPartialAddressResponse.scala
@@ -1,6 +1,7 @@
 package uk.gov.ons.addressIndex.model.server.response.partialaddress
 
 import play.api.libs.json.{Format, Json}
+import uk.gov.ons.addressIndex.model.server.response.address.AddressResponseAddress
 
 /**
   * Contains relevant, to the address request, data
@@ -13,7 +14,7 @@ import play.api.libs.json.{Format, Json}
   */
 case class AddressByPartialAddressResponse(
                                       input: String,
-                                      addresses: Seq[AddressResponsePartialAddress],
+                                      addresses: Seq[AddressResponseAddress],
                                       filter: String,
                                       historical: Boolean,
                                       limit: Int,
@@ -21,8 +22,8 @@ case class AddressByPartialAddressResponse(
                                       total: Long,
                                       maxScore: Double,
                                       startDate: String,
-                                      endDate: String
-                                    )
+                                      endDate: String,
+                                      verbose:  Boolean)
 
 object AddressByPartialAddressResponse {
   implicit lazy val addressByPartialAddressResponseFormat: Format[AddressByPartialAddressResponse] = Json.format[AddressByPartialAddressResponse]

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/postcode/AddressByPostcodeResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/postcode/AddressByPostcodeResponse.scala
@@ -22,7 +22,8 @@ case class AddressByPostcodeResponse(
                                     total: Long,
                                     maxScore: Double,
                                     startDate: String,
-                                    endDate: String
+                                    endDate: String,
+                                    verbose: Boolean
                                   )
 
 object AddressByPostcodeResponse {

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/uprn/AddressByUprnResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/uprn/AddressByUprnResponse.scala
@@ -10,8 +10,10 @@ import uk.gov.ons.addressIndex.model.server.response.address.AddressResponseAddr
 */
 case class AddressByUprnResponse(
   address: Option[AddressResponseAddress],
+  historical: Boolean,
   startDate: String,
-  endDate: String
+  endDate: String,
+  verbose: Boolean
 )
 
 object AddressByUprnResponse {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -135,7 +135,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
           case HybridAddresses(hybridAddresses, maxScore, total) =>
 
             val addresses: Seq[AddressResponseAddress] = hybridAddresses.map(
-              AddressResponseAddress.fromHybridAddress
+              AddressResponseAddress.fromHybridAddress(_,true)
             )
             //  calculate the elastic denominator value which will be used when scoring each address
             val elasticDenominator = Try(
@@ -191,7 +191,8 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
                   total = newTotal,
                   maxScore = maxScore,
                   sampleSize = limitExpanded,
-                  matchthreshold = thresholdFloat
+                  matchthreshold = thresholdFloat,
+                  verbose = verb
                 ),
                 status = OkAddressResponseStatus
               )

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -44,7 +44,8 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
                    lat: Option[String] = None, lon: Option[String] = None,
                    startDate: Option[String] = None, endDate: Option[String] = None,
                    historical: Option[String] = None,
-                   matchthreshold: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
+                   matchthreshold: Option[String] = None,
+                   verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
 
     val startingTime: Long = System.currentTimeMillis()
     val ip: String = req.remoteAddress
@@ -69,6 +70,11 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
       case None => true
     }
 
+    val verb = verbose match {
+      case Some(x) => Try(x.toBoolean).getOrElse(true)
+      case None => true
+    }
+
     // validate radius parameters
     val rangeVal = rangekm.getOrElse("")
     val latVal = lat.getOrElse("")
@@ -83,6 +89,10 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
         endDate=endDateVal, startDate = startDateVal, historical = hist, rangekm = rangeVal, lat = latVal, lon = lonVal,
         badRequestMessage = badRequestErrorMessage, formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid)
+    }
+
+    def trimAddresses (fullAddresses: Seq[AddressResponseAddress]): Seq[AddressResponseAddress] = {
+      fullAddresses.map{address => address.copy(nag=None,paf=None,relatives=None,crossRefs=None)}
     }
 
     val limitInt = Try(limval.toInt).toOption.getOrElse(defLimit)
@@ -149,6 +159,10 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
             // trim the result list according to offset and limit paramters
             val limitedSortedAddresses = sortedAddresses.drop(offsetInt).take(limitInt)
 
+            // if verbose is false, strip out full address details (these are needed for score so must be
+           // removed retrospectively)
+            val finalAddresses = if (verb) limitedSortedAddresses else trimAddresses(limitedSortedAddresses)
+
             addresses.foreach { address =>
               writeLog(
                 formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
@@ -164,7 +178,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
                 dataVersion = dataVersion,
                 response = AddressBySearchResponse(
                   tokens = tokens,
-                  addresses = limitedSortedAddresses,
+                  addresses = finalAddresses,
                   filter = filterString,
                   historical = hist,
                   rangekm = rangeVal,

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
@@ -37,7 +37,7 @@ class DebugController@Inject()(val controllerComponents: ControllerComponents,
     * @param input input for which the query should be generated
     * @return query that is ought to be sent to Elastic (for debug purposes)
     */
-  def queryDebug(input: String, classificationfilter: Option[String] = None, rangekm: Option[String] = None, lat: Option[String] = None, lon: Option[String] = None, startDate: Option[String], endDate: Option[String], historical: Option[String] = None): Action[AnyContent] = Action { implicit req =>
+  def queryDebug(input: String, classificationfilter: Option[String] = None, rangekm: Option[String] = None, lat: Option[String] = None, lon: Option[String] = None, startDate: Option[String], endDate: Option[String], historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action { implicit req =>
     val tokens = parser.parse(input)
 
     val filterString = classificationfilter.getOrElse("")

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -58,8 +58,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     }
 
     val verb = verbose match {
-      case Some(x) => Try(x.toBoolean).getOrElse(true)
-      case None => true
+      case Some(x) => Try(x.toBoolean).getOrElse(false)
+      case None => false
     }
 
     def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -4,7 +4,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.ons.addressIndex.model.db.index.HybridAddresses
-import uk.gov.ons.addressIndex.model.server.response.address.{FailedRequestToEsPartialAddressError, OkAddressResponseStatus}
+import uk.gov.ons.addressIndex.model.server.response.address.{AddressResponseAddress, FailedRequestToEsPartialAddressError, OkAddressResponseStatus}
 import uk.gov.ons.addressIndex.model.server.response.partialaddress.{AddressByPartialAddressResponse, AddressByPartialAddressResponseContainer, AddressResponsePartialAddress}
 import uk.gov.ons.addressIndex.server.modules.response.{AddressControllerResponse, PartialAddressControllerResponse}
 import uk.gov.ons.addressIndex.server.modules.validation.PartialAddressControllerValidation
@@ -37,7 +37,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
   def partialAddressQuery(input: String, offset: Option[String] = None, limit: Option[String] = None,
     classificationfilter: Option[String] = None, startDate: Option[String], endDate: Option[String],
-    historical: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
+    historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
     val startingTime = System.currentTimeMillis()
 
     // get the defaults and maxima for the paging parameters from the config
@@ -53,6 +53,11 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     val endDateVal = endDate.getOrElse("")
 
     val hist = historical match {
+      case Some(x) => Try(x.toBoolean).getOrElse(true)
+      case None => true
+    }
+
+    val verb = verbose match {
       case Some(x) => Try(x.toBoolean).getOrElse(true)
       case None => true
     }
@@ -97,8 +102,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
         request.map {
           case HybridAddresses(hybridAddresses, maxScore, total) =>
-            val addresses: Seq[AddressResponsePartialAddress] = hybridAddresses.map(
-              AddressResponsePartialAddress.fromHybridAddress
+            val addresses: Seq[AddressResponseAddress] = hybridAddresses.map(
+              AddressResponseAddress.fromHybridAddress(_,verb)
             )
 
             addresses.foreach { address =>
@@ -124,7 +129,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
                   total = total,
                   maxScore = maxScore,
                   startDate = startDateVal,
-                  endDate = endDateVal
+                  endDate = endDateVal,
+                  verbose  = verb
                 ),
                 status = OkAddressResponseStatus
               )

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -34,9 +34,14 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
     * @param uprn uprn of the address to be fetched
     * @return
     */
-  def uprnQuery(uprn: String, startDate: Option[String] = None, endDate: Option[String] = None, historical: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
+  def uprnQuery(uprn: String, startDate: Option[String] = None, endDate: Option[String] = None, historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
 
     val hist = historical match {
+      case Some(x) => Try(x.toBoolean).getOrElse(true)
+      case None => true
+    }
+
+    val verb = verbose match {
       case Some(x) => Try(x.toBoolean).getOrElse(true)
       case None => true
     }
@@ -79,7 +84,7 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
         request.map {
           case Some(hybridAddress) =>
 
-            val address = AddressResponseAddress.fromHybridAddress(hybridAddress)
+            val address = AddressResponseAddress.fromHybridAddress(hybridAddress,verb)
 
             writeLog(
               formattedOutput = address.formattedAddressNag, numOfResults = "1",
@@ -92,8 +97,10 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
                 dataVersion = dataVersion,
                 response = AddressByUprnResponse(
                   address = Some(address),
+                  historical = hist,
                   startDate = startDateVal,
-                  endDate = endDateVal
+                  endDate = endDateVal,
+                  verbose = verb
                 ),
                 status = OkAddressResponseStatus
               )

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -765,7 +765,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           // something that will indicate an empty result
           val tokens = requestData.tokens
           val emptyBulk = BulkAddress.empty(requestData)
-          val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(emptyBulk.hybridAddress)), tokens, 1D)
+          val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(emptyBulk.hybridAddress, true)), tokens, 1D)
           val emptyBulkAddress = AddressBulkResponseAddress.fromBulkAddress(emptyBulk, emptyScored.head, false)
           if (hybridAddresses.isEmpty) Seq(emptyBulkAddress)
           else {
@@ -774,7 +774,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             }
 
             val addressResponseAddresses = hybridAddresses.map { hybridAddress =>
-              AddressResponseAddress.fromHybridAddress(hybridAddress)
+              AddressResponseAddress.fromHybridAddress(hybridAddress, true)
             }
 
             //  calculate the elastic denominator value which will be used when scoring each address

--- a/server/app/uk/gov/ons/addressIndex/server/modules/response/PartialAddressControllerResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/response/PartialAddressControllerResponse.scala
@@ -26,7 +26,8 @@ trait PartialAddressControllerResponse extends AddressResponse {
       total = 0,
       maxScore = 0f,
       startDate = "",
-      endDate = ""
+      endDate = "",
+      verbose = true
     )
   }
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/response/PostcodeControllerResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/response/PostcodeControllerResponse.scala
@@ -19,7 +19,8 @@ trait PostcodeControllerResponse extends Response {
         total = 0,
         maxScore = 0f,
         startDate = "",
-        endDate = ""
+        endDate = "",
+        verbose = true
       ),
       status = NotFoundAddressResponseStatus,
       errors = Seq(NotFoundAddressResponseError)
@@ -61,7 +62,8 @@ trait PostcodeControllerResponse extends Response {
       total = 0,
       maxScore = 0f,
       startDate = "",
-      endDate = ""
+      endDate = "",
+      verbose = true
     )
   }
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/response/Response.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/response/Response.scala
@@ -92,7 +92,8 @@ trait Response {
       total = 0,
       sampleSize = 20,
       maxScore = 0f,
-      matchthreshold = 5f
+      matchthreshold = 5f,
+      verbose = true
     )
   }
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/response/UPRNControllerResponse.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/response/UPRNControllerResponse.scala
@@ -15,8 +15,10 @@ trait UPRNControllerResponse extends Response {
       dataVersion = dataVersion,
       response = AddressByUprnResponse(
         address = None,
+        historical = true,
         startDate = "",
-        endDate = ""
+        endDate = "",
+        verbose = true
       ),
       status = BadRequestAddressResponseStatus,
       errors = Seq(UprnNotNumericAddressResponseError)
@@ -29,8 +31,10 @@ trait UPRNControllerResponse extends Response {
       dataVersion = dataVersion,
       response = AddressByUprnResponse(
         address = optAddresses,
+        historical = true,
         startDate = "",
-        endDate = ""
+        endDate = "",
+        verbose = true
       ),
       status = OkAddressResponseStatus
     )
@@ -42,8 +46,10 @@ trait UPRNControllerResponse extends Response {
       dataVersion = dataVersion,
       response = AddressByUprnResponse(
         address = None,
+        historical = true,
         startDate = "",
-        endDate = ""
+        endDate = "",
+        verbose = true
       ),
       status = NotFoundAddressResponseStatus,
       errors = Seq(NotFoundAddressResponseError)
@@ -56,8 +62,10 @@ trait UPRNControllerResponse extends Response {
       dataVersion = dataVersion,
       response = AddressByUprnResponse(
         address = None,
+        historical = true,
         startDate = "",
-        endDate = ""
+        endDate = "",
+        verbose = true
       ),
       status = BadRequestAddressResponseStatus,
       errors = Seq(FormatNotSupportedAddressResponseError)

--- a/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/HopperScoreHelper.scala
@@ -40,8 +40,8 @@ object HopperScoreHelper  {
 
   def getScoresForBulks(addresses: Seq[BulkAddress], tokens: Map[String, String], elasticDenominator: Double): Seq[AddressResponseAddress] = {
     val startingTime = System.currentTimeMillis()
-    val localityParams = addresses.map(address => getLocalityParams(AddressResponseAddress.fromHybridAddress(address.hybridAddress),tokens))
-    val scoredAddresses = addresses.zipWithIndex.map{case (address, index) => addScoresToAddress(index, AddressResponseAddress.fromHybridAddress(address.hybridAddress), tokens, localityParams, elasticDenominator)}
+    val localityParams = addresses.map(address => getLocalityParams(AddressResponseAddress.fromHybridAddress(address.hybridAddress, true),tokens))
+    val scoredAddresses = addresses.zipWithIndex.map{case (address, index) => addScoresToAddress(index, AddressResponseAddress.fromHybridAddress(address.hybridAddress, true), tokens, localityParams, elasticDenominator)}
     val endingTime = System.currentTimeMillis()
     logger.trace("Hopper Score calucation time = "+(endingTime-startingTime)+" milliseconds")
     scoredAddresses

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -26,14 +26,16 @@ GET     /                   uk.gov.ons.addressIndex.server.controllers.general.A
 #    - name: historical
 #      description: Include historical addresses (default true)
 #    - name: matchthreshold
-#      description: minimum confidence score (percentage) for match to be included in results (default 5.0)
+#      description: Minimum confidence score (percentage) for match to be included in results (default 5.0)
+#    - name: verbose
+#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.address.AddressBySearchResponseContainer"
 ###
-GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], matchthreshold: Option[String])
+GET     /addresses          uk.gov.ons.addressIndex.server.controllers.AddressController.addressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], matchthreshold: Option[String], verbose: Option[String])
 
 ###
 #  summary: Return a list of codelists supported by the API
@@ -157,13 +159,15 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #      description: Date that address ceased to exist in the database (yyyy-MM-dd). Required if startDate given.
 #    - name: historical
 #      description: Include historical addresses (default true)
+#    - name: verbose
+#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.postcode.AddressByPostcodeResponseContainer"
 ###
-GET     /addresses/postcode/:postcode          uk.gov.ons.addressIndex.server.controllers.PostcodeController.postcodeQuery(postcode, offset: Option[String], limit: Option[String], classificationfilter: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String])
+GET     /addresses/postcode/:postcode          uk.gov.ons.addressIndex.server.controllers.PostcodeController.postcodeQuery(postcode, offset: Option[String], limit: Option[String], classificationfilter: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], verbose: Option[String])
 
 ###
 #  summary: Test elastic is connected.

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -201,11 +201,13 @@ GET     /es                 uk.gov.ons.addressIndex.server.controllers.DebugCont
 #      description: Date that address ceased to exist in the database (yyyy-MM-dd). Required if startDate given.
 #    - name: historical
 #      description: Include historical addresses (default true)
+#    - name: verbose
+#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 ###
-GET     /query-debug        uk.gov.ons.addressIndex.server.controllers.DebugController.queryDebug(input, classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String])
+GET     /query-debug        uk.gov.ons.addressIndex.server.controllers.DebugController.queryDebug(input, classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], verbose: Option[String])
 
 ###
 #  summary: Get version information.

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -105,13 +105,15 @@ GET     /codelists/logicalstatus      uk.gov.ons.addressIndex.server.controllers
 #      description: Date that address ceased to exist in the database (yyyy-MM-dd). Required if startDate given.
 #    - name: historical
 #      description: Include historical addresses (default true)
+#    - name: verbose
+#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.uprn.AddressByUprnResponseContainer"
 ###
-GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRNController.uprnQuery(uprn, startdate: Option[String], enddate: Option[String], historical: Option[String])
+GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRNController.uprnQuery(uprn, startdate: Option[String], enddate: Option[String], historical: Option[String], verbose: Option[String])
 
 
 ###
@@ -132,13 +134,15 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #      description: Date that address ceased to exist in the database (yyyy-MM-dd). Required if startDate given.
 #    - name: historical
 #      description: Include historical addresses (default true)
+#    - name: verbose
+#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 #      schema:
 #        $ref: "#/definitions/uk.gov.ons.addressIndex.model.server.response.partialaddress.AddressByPartialAddressResponseContainer"
 ###
-GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String])
+GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], verbose: Option[String])
 
 
 ###

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -135,7 +135,7 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #    - name: historical
 #      description: Include historical addresses (default true)
 #    - name: verbose
-#      description: Include the full address details in the response,  true or false, default true.
+#      description: Include the full address details in the response,  true or false, default false.
 #  responses:
 #    200:
 #      description: success

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -166,7 +166,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         Future.successful {
           requestsData.map(requestData => {
             val filledBulk = BulkAddress.fromHybridAddress(validHybridAddress, requestData)
-            val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(filledBulk.hybridAddress)), requestData.tokens, 1D)
+            val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(filledBulk.hybridAddress, true)), requestData.tokens, 1D)
             val filledBulkAddress = AddressBulkResponseAddress.fromBulkAddress(filledBulk, emptyScored.head, false)
 
             Right(Seq(filledBulkAddress))
@@ -197,7 +197,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       Future.successful{
         requestsData.map(requestData => {
           val filledBulk = BulkAddress.fromHybridAddress(validHybridAddress, requestData)
-          val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(filledBulk.hybridAddress)), requestData.tokens, 1D)
+          val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(filledBulk.hybridAddress, true)), requestData.tokens, 1D)
           val filledBulkAddress = AddressBulkResponseAddress.fromBulkAddress(filledBulk, emptyScored.head, false)
 
           Right(Seq(filledBulkAddress))
@@ -228,7 +228,7 @@ class AddressControllerSpec extends PlaySpec with Results {
           case requestData if requestData.tokens.values.exists(_ == "failed") => Left(requestData)
           case requestData => {
               val emptyBulk = BulkAddress.empty(requestData)
-              val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(emptyBulk.hybridAddress)),requestData.tokens, 1D)
+              val emptyScored = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(emptyBulk.hybridAddress, true)),requestData.tokens, 1D)
               val emptyBulkAddress =  AddressBulkResponseAddress.fromBulkAddress(emptyBulk, emptyScored.head, false)
 
               Right(Seq(emptyBulkAddress))
@@ -303,9 +303,11 @@ class AddressControllerSpec extends PlaySpec with Results {
         apiVersion = apiVersionExpected,
         dataVersion = dataVersionExpected,
         response = AddressByUprnResponse(
-          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress)),
+          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
+          historical = true,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -327,9 +329,11 @@ class AddressControllerSpec extends PlaySpec with Results {
         apiVersion = apiVersionExpected,
         dataVersion = dataVersionExpected,
         response = AddressByUprnResponse(
-          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress)),
+          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
+          historical = true,
           startDate = "2013-01-01",
-          endDate = "2014-01-01"
+          endDate = "2014-01-01",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -352,7 +356,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByPostcodeResponse(
           postcode = "some query",
-          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
           filter = "",
           historical = true,
           limit = 100,
@@ -360,7 +364,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 1,
           maxScore = 1.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -384,7 +389,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByPostcodeResponse(
           postcode = "some query",
-          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
           filter = "",
           historical = true,
           limit = 100,
@@ -392,7 +397,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 1,
           maxScore = 1.0f,
           startDate = "2013-01-01",
-          endDate = "2014-01-01"
+          endDate = "2014-01-01",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -416,7 +422,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByPartialAddressResponse(
           input = "some query",
-          addresses = Seq(AddressResponsePartialAddress.fromHybridAddress(validHybridAddress)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress,false)),
           filter = "",
           historical = true,
           limit = 20,
@@ -424,7 +430,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 1,
           maxScore = 1.0f,
           startDate = "2013-01-01",
-          endDate = "2014-01-01"
+          endDate = "2014-01-01",
+          verbose = false
         ),
         OkAddressResponseStatus
       ))
@@ -449,7 +456,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByPartialAddressResponse(
           input = "some query",
-          addresses = Seq(AddressResponsePartialAddress.fromHybridAddress(validHybridAddress)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
           filter = "",
           historical = true,
           limit = 20,
@@ -457,7 +464,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 1,
           maxScore = 1.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = false
         ),
         OkAddressResponseStatus
       ))
@@ -481,7 +489,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         AddressBySearchResponse(
           tokens = Map.empty,
-          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),Map.empty,-1D),
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),Map.empty,-1D),
           filter = "",
           historical = true,
           rangekm = "",
@@ -494,7 +502,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 1.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -518,7 +527,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         AddressBySearchResponse(
           tokens = Map.empty,
-          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),Map.empty,-1D),
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress,true)),Map.empty,-1D),
           filter = "",
           historical = true,
           rangekm = "1",
@@ -531,7 +540,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 1.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -555,7 +565,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         AddressBySearchResponse(
           tokens = Map.empty,
-          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress)),Map.empty,-1D),
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),Map.empty,-1D),
           filter = "",
           historical = true,
           rangekm = "",
@@ -568,7 +578,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 1.0f,
           matchthreshold = 5f,
           startDate = "2013-01-01",
-          endDate = "2014-01-01"
+          endDate = "2014-01-01",
+          verbose = true
         ),
         OkAddressResponseStatus
       ))
@@ -604,7 +615,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(FilterInvalidError)
@@ -642,7 +654,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetNotNumericAddressResponseError)
@@ -674,7 +687,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetNotNumericPostcodeAddressResponseError)
@@ -711,7 +725,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitNotNumericAddressResponseError)
@@ -743,7 +758,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitNotNumericPostcodeAddressResponseError)
@@ -780,7 +796,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetTooSmallAddressResponseError)
@@ -812,7 +829,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetTooSmallPostcodeAddressResponseError)
@@ -849,7 +867,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitTooSmallAddressResponseError)
@@ -881,7 +900,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitTooSmallPostcodeAddressResponseError)
@@ -918,7 +938,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetTooLargeAddressResponseError)
@@ -950,7 +971,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(OffsetTooLargePostcodeAddressResponseError)
@@ -987,7 +1009,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitTooLargeAddressResponseError)
@@ -1019,7 +1042,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LimitTooLargePostcodeAddressResponseError)
@@ -1056,7 +1080,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(RangeNotNumericAddressResponseError)
@@ -1093,7 +1118,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LatitudeNotNumericAddressResponseError)
@@ -1130,7 +1156,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LongitudeNotNumericAddressResponseError)
@@ -1167,7 +1194,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LatitudeTooFarNorthAddressResponseError)
@@ -1204,7 +1232,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LongitudeTooFarEastAddressResponseError)
@@ -1241,7 +1270,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LatitudeTooFarSouthAddressResponseError)
@@ -1278,7 +1308,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(LongitudeTooFarWestAddressResponseError)
@@ -1315,7 +1346,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EmptyQueryAddressResponseError)
@@ -1352,7 +1384,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(StartDateInvalidResponseError)
@@ -1389,7 +1422,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EndDateInvalidResponseError)
@@ -1426,7 +1460,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(StartDateInvalidResponseError)
@@ -1463,7 +1498,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EndDateInvalidResponseError)
@@ -1500,7 +1536,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(StartDateInvalidResponseError)
@@ -1537,7 +1574,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EndDateInvalidResponseError)
@@ -1574,7 +1612,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(StartDateInvalidResponseError)
@@ -1611,7 +1650,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EndDateInvalidResponseError)
@@ -1643,7 +1683,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(EmptyQueryPostcodeAddressResponseError)
@@ -1680,7 +1721,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         TooManyRequestsResponseStatus,
         errors = Seq(FailedRequestToEsError)
@@ -1712,7 +1754,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           total = 0,
           maxScore = 0.0f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         TooManyRequestsResponseStatus,
         errors = Seq(FailedRequestToEsError)
@@ -1749,7 +1792,8 @@ class AddressControllerSpec extends PlaySpec with Results {
           maxScore = 0.0f,
           matchthreshold = 5f,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         TooManyRequestsResponseStatus,
         errors = Seq(FailedRequestToEsError)
@@ -1773,8 +1817,10 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByUprnResponse(
           address = None,
+          historical = true,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         BadRequestAddressResponseStatus,
         errors = Seq(UprnNotNumericAddressResponseError)
@@ -1798,8 +1844,10 @@ class AddressControllerSpec extends PlaySpec with Results {
         dataVersion = dataVersionExpected,
         response = AddressByUprnResponse(
           address = None,
+          historical = true,
           startDate = "",
-          endDate = ""
+          endDate = "",
+          verbose = true
         ),
         NotFoundAddressResponseStatus,
         errors = Seq(NotFoundAddressResponseError)

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -257,8 +257,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       val expected = AddressResponseAddress(
         uprn = givenPaf.uprn,
         parentUprn = givenPaf.uprn,
-        relatives = Seq(givenRelativeResponse),
-        crossRefs = Seq(givenCrossRefResponse),
+        relatives = Some(Seq(givenRelativeResponse)),
+        crossRefs = Some(Seq(givenCrossRefResponse)),
         formattedAddress = "mixedNag",
         formattedAddressNag = "mixedNag",
         formattedAddressPaf = "mixedPaf",

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -277,7 +277,7 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       )
 
       // When
-      val result = AddressResponseAddress.fromHybridAddress(hybrid)
+      val result = AddressResponseAddress.fromHybridAddress(hybrid, true)
 
       // Then
       result shouldBe expected

--- a/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/utils/HopperScoreHelperTest.scala
@@ -185,8 +185,8 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
   val mockAddressResponseAddress = AddressResponseAddress(
     uprn = "",
     parentUprn = "",
-    relatives = Seq(mockRelativeResponse),
-    crossRefs = Seq(mockCrossRefResponse),
+    relatives = Some(Seq(mockRelativeResponse)),
+    crossRefs = Some(Seq(mockCrossRefResponse)),
     formattedAddress = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressNag = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressPaf = "7, GATE REACH, EXETER, EX2 9GA",
@@ -203,8 +203,8 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
   val mockAddressResponseAddress1 = AddressResponseAddress(
     uprn = "",
     parentUprn = "",
-    relatives = Seq(mockRelativeResponse),
-    crossRefs = Seq(mockCrossRefResponse),
+    relatives = Some(Seq(mockRelativeResponse)),
+    crossRefs = Some(Seq(mockCrossRefResponse)),
     formattedAddress = "7, GATE REACH, EXETER, PO7 PO7",
     formattedAddressNag = "7, GATE REACH, EXETER, PO7 PO7",
     formattedAddressPaf = "7, GATE REACH, EXETER, PO7 PO7",
@@ -221,8 +221,8 @@ class HopperScoreHelperTest extends FlatSpec with Matchers {
   val mockAddressResponseAddressWithScores = AddressResponseAddress(
     uprn = "",
     parentUprn = "",
-    relatives = Seq(mockRelativeResponse),
-    crossRefs = Seq(mockCrossRefResponse),
+    relatives = Some(Seq(mockRelativeResponse)),
+    crossRefs = Some(Seq(mockCrossRefResponse)),
     formattedAddress = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressNag = "7, GATE REACH, EXETER, EX2 9GA",
     formattedAddressPaf = "7, GATE REACH, EXETER, EX2 9GA",


### PR DESCRIPTION
main single match - verbose flag defaults to true and unwanted data must be discarded after scoring and thresholding
postcode - verbose flag defaults to true (might want to make this false), unwanted data items not gathered
UPRN - verbose flag defaults to true, unwanted data items not gathered
partial - verbose flag defaults to false, unwanted data items not gathered
for consistency partial now uses the same objects as the others rather than its own so the output is slightly different.
The UI has been changed to support verbose settings, and false is used when expanding relatives, everything else uses verbose true.
Unit tests have been updated but what I haven't done is double up everything for a verbose and concise version - will do a separate PR for this if needed and any other changes we decide upon (such as the default for postcode)