### PR TITLE
Implement Consistent Concise and Verbose output and add tests

### DIFF
--- a/client/src/test/scala/uk/gov/ons/addressIndex/client/AddressIndexClientTest.scala
+++ b/client/src/test/scala/uk/gov/ons/addressIndex/client/AddressIndexClientTest.scala
@@ -50,6 +50,7 @@ class AddressIndexClientTest extends FlatSpec with Matchers {
     val lat = "lat"
     val lon = "lon"
     val historical = true
+    val verbose = true
     val matchthreshold = 5
     val startdate = "startdate"
     val enddate = "enddate"
@@ -68,7 +69,7 @@ class AddressIndexClientTest extends FlatSpec with Matchers {
         limit = "10",
         offset = "0",
         apiKey = "",
-        verbose = true
+        verbose = verbose
       )
     ).queryString
     val expected = Map(
@@ -77,6 +78,7 @@ class AddressIndexClientTest extends FlatSpec with Matchers {
       "historical" -> Seq("true"),
       "matchthreshold" -> Seq("5"),
       "rangekm" -> Seq("rangekm"),
+      "verbose" -> Seq("true"),
       "lat" -> Seq("lat"),
       "lon" -> Seq("lon"),
       "startdate" -> Seq("startdate"),

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/AddressIndexModel.scala
@@ -45,6 +45,19 @@ case class AddressIndexPostcodeRequest(
   apiKey: String
 )
 
+case class AddressIndexPartialRequest(
+  partial: String,
+  filter: String,
+  historical: Boolean,
+  startdate: String,
+  enddate: String,
+  limit: String,
+  offset: String,
+  verbose: Boolean,
+  id: UUID,
+  apiKey: String
+)
+
 /**
   * The body of the request that is sent to the bulk api endpoint
   * @param addresses collection of addresses that will be queried

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -71,8 +71,8 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
     }
 
     val verb = verbose match {
-      case Some(x) => Try(x.toBoolean).getOrElse(true)
-      case None => true
+      case Some(x) => Try(x.toBoolean).getOrElse(false)
+      case None => false
     }
 
     // validate radius parameters

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
@@ -37,7 +37,7 @@ class DebugController@Inject()(val controllerComponents: ControllerComponents,
     * @param input input for which the query should be generated
     * @return query that is ought to be sent to Elastic (for debug purposes)
     */
-  def queryDebug(input: String, classificationfilter: Option[String] = None, rangekm: Option[String] = None, lat: Option[String] = None, lon: Option[String] = None, startDate: Option[String], endDate: Option[String], historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action { implicit req =>
+  def queryDebug(input: String, classificationfilter: Option[String] = None, rangekm: Option[String] = None, lat: Option[String] = None, lon: Option[String] = None, startDate: Option[String], endDate: Option[String], historical: Option[String] = None): Action[AnyContent] = Action { implicit req =>
     val tokens = parser.parse(input)
 
     val filterString = classificationfilter.getOrElse("")

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
@@ -57,8 +57,8 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
     }
 
     val verb = verbose match {
-      case Some(x) => Try(x.toBoolean).getOrElse(true)
-      case None => true
+      case Some(x) => Try(x.toBoolean).getOrElse(false)
+      case None => false
     }
 
     def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -42,8 +42,8 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
     }
 
     val verb = verbose match {
-      case Some(x) => Try(x.toBoolean).getOrElse(true)
-      case None => true
+      case Some(x) => Try(x.toBoolean).getOrElse(false)
+      case None => false
     }
 
     val startDateVal = startDate.getOrElse("")

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -28,7 +28,7 @@ GET     /                   uk.gov.ons.addressIndex.server.controllers.general.A
 #    - name: matchthreshold
 #      description: Minimum confidence score (percentage) for match to be included in results (default 5.0)
 #    - name: verbose
-#      description: Include the full address details in the response,  true or false, default true.
+#      description: Include the full address details in the response,  true or false, default false.
 #  responses:
 #    200:
 #      description: success
@@ -106,7 +106,7 @@ GET     /codelists/logicalstatus      uk.gov.ons.addressIndex.server.controllers
 #    - name: historical
 #      description: Include historical addresses (default true)
 #    - name: verbose
-#      description: Include the full address details in the response,  true or false, default true.
+#      description: Include the full address details in the response,  true or false, default false.
 #  responses:
 #    200:
 #      description: success
@@ -164,7 +164,7 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #    - name: historical
 #      description: Include historical addresses (default true)
 #    - name: verbose
-#      description: Include the full address details in the response,  true or false, default true.
+#      description: Include the full address details in the response,  true or false, default false.
 #  responses:
 #    200:
 #      description: success
@@ -201,13 +201,11 @@ GET     /es                 uk.gov.ons.addressIndex.server.controllers.DebugCont
 #      description: Date that address ceased to exist in the database (yyyy-MM-dd). Required if startDate given.
 #    - name: historical
 #      description: Include historical addresses (default true)
-#    - name: verbose
-#      description: Include the full address details in the response,  true or false, default true.
 #  responses:
 #    200:
 #      description: success
 ###
-GET     /query-debug        uk.gov.ons.addressIndex.server.controllers.DebugController.queryDebug(input, classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String], verbose: Option[String])
+GET     /query-debug        uk.gov.ons.addressIndex.server.controllers.DebugController.queryDebug(input, classificationfilter: Option[String], rangekm: Option[String], lat: Option[String], lon: Option[String], startdate: Option[String], enddate: Option[String], historical: Option[String])
 
 ###
 #  summary: Get version information.

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -295,7 +295,33 @@ class AddressControllerSpec extends PlaySpec with Results {
 
   "Address controller" should {
 
-    "reply with a found address (by uprn)" in {
+    "reply with a found address in concise format (by uprn)" in {
+      // Given
+      val controller = uprnController
+
+      val expected = Json.toJson(AddressByUprnResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByUprnResponse(
+          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
+          historical = true,
+          startDate = "",
+          endDate = "",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn, verbose=Some("false")).apply(FakeRequest())
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in verbose format (by uprn)" in {
       // Given
       val controller = uprnController
 
@@ -313,7 +339,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn).apply(FakeRequest())
+      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn,  verbose=Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -321,7 +347,33 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual mustBe expected
     }
 
-    "reply on a found address (by uprn query with start and end date)" in {
+    "reply on a found address in concise format (by uprn query with start and end date)" in {
+      // Given
+      val controller = uprnController
+
+      val expected = Json.toJson(AddressByUprnResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByUprnResponse(
+          address = Some(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
+          historical = true,
+          startDate = "2013-01-01",
+          endDate = "2014-01-01",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("false")).apply(FakeRequest())
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply on a found address in verbose format (by uprn query with start and end date)" in {
       // Given
       val controller = uprnController
 
@@ -339,7 +391,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn, Some("2013-01-01"), Some("2014-01-01")).apply(FakeRequest())
+      val result: Future[Result] = controller.uprnQuery(validHybridAddress.uprn, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -347,7 +399,40 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual mustBe expected
     }
 
-    "reply with a found address (by postcode)" in {
+    "reply with a found address in concise format (by postcode)" in {
+      // Given
+      val controller = postcodeController
+
+      val expected = Json.toJson(AddressByPostcodeResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByPostcodeResponse(
+          postcode = "some query",
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
+          filter = "",
+          historical = true,
+          limit = 100,
+          offset = 0,
+          total = 1,
+          maxScore = 1.0f,
+          startDate = "",
+          endDate = "",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = controller.postcodeQuery("some query",verbose=Some("false")).apply(FakeRequest())
+
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in verbose format (by postcode)" in {
       // Given
       val controller = postcodeController
 
@@ -371,7 +456,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = controller.postcodeQuery("some query").apply(FakeRequest())
+      val result: Future[Result] = controller.postcodeQuery("some query",verbose=Some("true")).apply(FakeRequest())
 
       val actual: JsValue = contentAsJson(result)
 
@@ -380,7 +465,40 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual mustBe expected
     }
 
-    "reply on a found address (by postcode query with start and end date)" in {
+    "reply on a found address in concise format (by postcode query with start and end date)" in {
+      // Given
+      val controller = postcodeController
+
+      val expected = Json.toJson(AddressByPostcodeResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByPostcodeResponse(
+          postcode = "some query",
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
+          filter = "",
+          historical = true,
+          limit = 100,
+          offset = 0,
+          total = 1,
+          maxScore = 1.0f,
+          startDate = "2013-01-01",
+          endDate = "2014-01-01",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = controller.postcodeQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("false")).apply(FakeRequest())
+
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply on a found address in verbose format (by postcode query with start and end date)" in {
       // Given
       val controller = postcodeController
 
@@ -404,7 +522,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = controller.postcodeQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01")).apply(FakeRequest())
+      val result: Future[Result] = controller.postcodeQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("true")).apply(FakeRequest())
 
       val actual: JsValue = contentAsJson(result)
 
@@ -413,7 +531,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual mustBe expected
     }
 
-    "reply on a found address (by partial address query with start and end date)" in {
+    "reply on a found address in concise format (by partial address query with start and end date)" in {
       // Given
       val controller = addressController
 
@@ -437,7 +555,40 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01")).apply(FakeRequest())
+      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("false")).apply(FakeRequest())
+
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply on a found address in verbose format (by partial address query with start and end date)" in {
+      // Given
+      val controller = addressController
+
+      val expected = Json.toJson(AddressByPartialAddressResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByPartialAddressResponse(
+          input = "some query",
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress,true)),
+          filter = "",
+          historical = true,
+          limit = 20,
+          offset = 0,
+          total = 1,
+          maxScore = 1.0f,
+          startDate = "2013-01-01",
+          endDate = "2014-01-01",
+          verbose = true
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, Some("2013-01-01"), Some("2014-01-01"), verbose=Some("true")).apply(FakeRequest())
 
       val actual: JsValue = contentAsJson(result)
 
@@ -447,7 +598,7 @@ class AddressControllerSpec extends PlaySpec with Results {
     }
 
 
-    "reply on a found address (by partial)" in {
+    "reply on a found address in concise format (by partial)" in {
       // Given
       val controller = addressController
 
@@ -471,7 +622,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, None, None).apply(FakeRequest())
+      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, None, None, verbose=Some("false")).apply(FakeRequest())
 
       val actual: JsValue = contentAsJson(result)
 
@@ -480,7 +631,77 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual mustBe expected
     }
 
-    "reply with a found address (by address query)" in {
+    "reply on a found address in verbose format (by partial)" in {
+      // Given
+      val controller = addressController
+
+      val expected = Json.toJson(AddressByPartialAddressResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        response = AddressByPartialAddressResponse(
+          input = "some query",
+          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
+          filter = "",
+          historical = true,
+          limit = 20,
+          offset = 0,
+          total = 1,
+          maxScore = 1.0f,
+          startDate = "",
+          endDate = "",
+          verbose = true
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result: Future[Result] = partialAddressController.partialAddressQuery("some query", None, None, None, None, None, verbose=Some("true")).apply(FakeRequest())
+
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in concise format (by address query)" in {
+      // Given
+      val controller = addressController
+
+      val expected = Json.toJson(AddressBySearchResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        AddressBySearchResponse(
+          tokens = Map.empty,
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),Map.empty,-1D),
+          filter = "",
+          historical = true,
+          rangekm = "",
+          latitude = "",
+          longitude = "",
+          limit = 10,
+          offset = 0,
+          total = 1,
+          sampleSize = 20,
+          maxScore = 1.0f,
+          matchthreshold = 5f,
+          startDate = "",
+          endDate = "",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result = controller.addressQuery("some query", verbose = Some("false")).apply(FakeRequest())
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in verbose format (by address query)" in {
       // Given
       val controller = addressController
 
@@ -509,7 +730,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result = controller.addressQuery("some query").apply(FakeRequest())
+      val result = controller.addressQuery("some query", verbose = Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -518,7 +739,44 @@ class AddressControllerSpec extends PlaySpec with Results {
     }
 
 
-    "reply with a found address (by address query with radius)" in {
+    "reply with a found address in concise format (by address query with radius)" in {
+      // Given
+      val controller = addressController
+
+      val expected = Json.toJson(AddressBySearchResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        AddressBySearchResponse(
+          tokens = Map.empty,
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress,false)),Map.empty,-1D),
+          filter = "",
+          historical = true,
+          rangekm = "1",
+          latitude = "50.705948",
+          longitude = "-3.5091076",
+          limit = 10,
+          offset = 0,
+          total = 1,
+          sampleSize = 20,
+          maxScore = 1.0f,
+          matchthreshold = 5f,
+          startDate = "",
+          endDate = "",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result = controller.addressQuery("some query", None, None, None, Some("1"), Some("50.705948"), Some("-3.5091076"), verbose=Some("false")).apply(FakeRequest())
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in verbose (by address query with radius)" in {
       // Given
       val controller = addressController
 
@@ -547,7 +805,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result = controller.addressQuery("some query", None, None, None, Some("1"), Some("50.705948"), Some("-3.5091076")).apply(FakeRequest())
+      val result = controller.addressQuery("some query", None, None, None, Some("1"), Some("50.705948"), Some("-3.5091076"), verbose=Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
@@ -556,7 +814,44 @@ class AddressControllerSpec extends PlaySpec with Results {
     }
 
 
-    "reply with a found address (by address query with start and end date)" in {
+    "reply with a found address in concise format (by address query with start and end date)" in {
+      // Given
+      val controller = addressController
+
+      val expected = Json.toJson(AddressBySearchResponseContainer(
+        apiVersion = apiVersionExpected,
+        dataVersion = dataVersionExpected,
+        AddressBySearchResponse(
+          tokens = Map.empty,
+          addresses = HopperScoreHelper.getScoresForAddresses(Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),Map.empty,-1D),
+          filter = "",
+          historical = true,
+          rangekm = "",
+          latitude = "",
+          longitude = "",
+          limit = 10,
+          offset = 0,
+          total = 1,
+          sampleSize = 20,
+          maxScore = 1.0f,
+          matchthreshold = 5f,
+          startDate = "2013-01-01",
+          endDate = "2014-01-01",
+          verbose = false
+        ),
+        OkAddressResponseStatus
+      ))
+
+      // When
+      val result = controller.addressQuery("some query", None, None, None, None, None, None, Some("2013-01-01"), Some("2014-01-01"),verbose=Some("false")).apply(FakeRequest())
+      val actual: JsValue = contentAsJson(result)
+
+      // Then
+      status(result) mustBe OK
+      actual mustBe expected
+    }
+
+    "reply with a found address in verbose format (by address query with start and end date)" in {
       // Given
       val controller = addressController
 
@@ -585,13 +880,14 @@ class AddressControllerSpec extends PlaySpec with Results {
       ))
 
       // When
-      val result = controller.addressQuery("some query", None, None, None, None, None, None, Some("2013-01-01"), Some("2014-01-01")).apply(FakeRequest())
+      val result = controller.addressQuery("some query", None, None, None, None, None, None, Some("2013-01-01"), Some("2014-01-01"),verbose=Some("true")).apply(FakeRequest())
       val actual: JsValue = contentAsJson(result)
 
       // Then
       status(result) mustBe OK
       actual mustBe expected
     }
+
 
     "reply with a 400 error if an invalid filter value is supplied" in {
       // Given


### PR DESCRIPTION
All outputs now default to concise (verbose=false)
Unit tests for both options