### PR TITLE
Add fallback query to typeahead

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -171,30 +171,30 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       if (inputNumber.isEmpty) {
         if (filters.isEmpty) {
           if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-          else must(multiMatchQuery(input).matchType("phrase").slop(3).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+          else must(multiMatchQuery(input).matchType("phrase").slop(4).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
         } else {
           if (filterType == "prefix") {
             if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-            else must(multiMatchQuery(input).matchType("phrase").slop(3).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+            else must(multiMatchQuery(input).matchType("phrase").slop(4).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
           }
           else {
             if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-            else must(multiMatchQuery(input).matchType("phrase").slop(3)fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+            else must(multiMatchQuery(input).matchType("phrase").slop(4)fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
           }
         }
       }
       else {
         if (filters.isEmpty) {
           if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-          else must(multiMatchQuery(input).matchType("phrase").slop(3).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+          else must(multiMatchQuery(input).matchType("phrase").slop(4).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
         } else {
           if (filterType == "prefix") {
             if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-            else must(multiMatchQuery(input).matchType("phrase").slop(3).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+            else must(multiMatchQuery(input).matchType("phrase").slop(4).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(prefixQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
           }
           else {
             if (fallback) must(multiMatchQuery(input).matchType("best_fields").fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
-            else must(multiMatchQuery(input).matchType("phrase").slop(3).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
+            else must(multiMatchQuery(input).matchType("phrase").slop(4).fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf")).should(matchQuery("lpi.paoStartNumber",inputNumber)).filter(Seq(Option(termQuery("lpi.classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery).flatten)
           }
         }
       }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -78,6 +78,20 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
     }
   }
 
+  /**
+    * Generates request to get address from partial string (e.g typeahead)
+    * Pass on to fallback if needed
+    *
+    * @param input             the partial string to be searched
+    * @param start start result
+    * @param limit maximum number of results
+    * @param filters           classification filter
+    * @param startDate         start date
+    * @param endDate           end date
+    * @param queryParamsConfig config
+    * @param historical        historical flag
+    * @return Search definition containing query to the ES
+    */
   def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses] = {
 
     val request = generateQueryPartialAddressRequest(input, filters, startDate, endDate, queryParamsConfig, historical, false).start(start).limit(limit)
@@ -90,6 +104,20 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
     endResult.flatten
   }
 
+  /**
+    * Generates request to get address from partial string (e.g typeahead)
+    * Fallback version
+    *
+    * @param input the partial string to be searched
+    * @param start start result
+    * @param limit maximum number of results
+    * @param filters classification filter
+    * @param startDate start date
+    * @param endDate end date
+    * @param queryParamsConfig config
+    * @param historical historical flag
+    * @return Search definition containing query to the ES
+    */
   def queryPartialAddressFallback(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses] = {
     logger.warn("in fallback")
     val fallback = generateQueryPartialAddressRequest(input, filters, startDate, endDate, queryParamsConfig, historical, true).start(start).limit(limit)
@@ -97,10 +125,16 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
   }
 
   /**
-    * Generates request to get address from ES by UPRN
+    * Generates request to get address from partial string (e.g typeahead)
     * Public for tests
     *
-    * @param input the uprn of the fetched address
+    * @param input partial string
+    * @param filters classification filter
+    * @param startDate start date
+    * @param endDate end date
+    * @param queryParamsConfig config
+    * @param historical historical flag
+    * @param fallback flag to indicate if fallback query is required
     * @return Search definition containing query to the ES
     */
   def generateQueryPartialAddressRequest(input: String, filters: String, startDate: String, endDate: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, fallback: Boolean = false): SearchDefinition = {

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -218,8 +218,8 @@ addressIndex {
       // hybridIndex = "test3a"
       hybridIndex = ${?ONS_AI_API_HYBRID_INDEX}
 
-  //    hybridIndexHistorical = "hybrid_latest"
-      hybridIndexHistorical = "lowertest"
+      hybridIndexHistorical = "hybrid_latest"
+  //    hybridIndexHistorical = "lowertest"
       // hybridIndexHistorical = "hybrid-historical_39_100316_1529495794240"
       // hybridIndexHistorical = "test8h"
       // hybridIndexHistorical = "test3a"

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -218,8 +218,8 @@ addressIndex {
       // hybridIndex = "test3a"
       hybridIndex = ${?ONS_AI_API_HYBRID_INDEX}
 
-      hybridIndexHistorical = "hybrid_latest"
-//      hybridIndexHistorical = "lowertest"
+  //    hybridIndexHistorical = "hybrid_latest"
+      hybridIndexHistorical = "lowertest"
       // hybridIndexHistorical = "hybrid-historical_39_100316_1529495794240"
       // hybridIndexHistorical = "test8h"
       // hybridIndexHistorical = "test3a"

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -747,7 +747,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            					"query": "h4",
            					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
            					"type": "phrase",
-                    "slop":3
+                    "slop":4
            				}
            			}],
            			"should": [{
@@ -803,7 +803,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            					"query": "h4",
            					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
            					"type": "phrase",
-                    "slop":3
+                    "slop":4
            				}
            			}],
            			"should": [{
@@ -2598,7 +2598,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"7 Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "should":[{
@@ -2647,7 +2647,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "filter":[{
@@ -2690,7 +2690,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"7 Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "should":[{
@@ -2746,7 +2746,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"7 Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "should":[{
@@ -2802,7 +2802,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "filter":[{
@@ -2851,7 +2851,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "query":"Gate Re",
                   "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
                   "type":"phrase",
-                  "slop":3
+                  "slop":4
                 }
               }],
               "filter":[{


### PR DESCRIPTION
If the very fast "phrase" query yields no results, a slower "best fields" query is done as a second attempt. Want to test this in Test for a while, also try a higher "slop" for the phrase query.