### PR TITLE
Update to logging to include verbose, endpoint and activity tags.

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -64,6 +64,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
     val threshval = matchthreshold.getOrElse(defThreshold.toString)
 
     val filterString = classificationfilter.getOrElse("")
+    val endpointType = "address"
 
     val hist = historical match {
       case Some(x) => Try(x.toBoolean).getOrElse(true)
@@ -80,7 +81,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
     val latVal = lat.getOrElse("")
     val lonVal = lon.getOrElse("")
 
-    def writeLog(badRequestErrorMessage: String = "", formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {
+    def writeLog(badRequestErrorMessage: String = "", formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
 
       val networkid = req.headers.get("authorization").getOrElse("Anon").split("_")(0)
 
@@ -88,7 +89,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
         input = input, offset = offval, limit = limval, filter = filterString,
         endDate=endDateVal, startDate = startDateVal, historical = hist, rangekm = rangeVal, lat = latVal, lon = lonVal,
         badRequestMessage = badRequestErrorMessage, formattedOutput = formattedOutput,
-        numOfResults = numOfResults, score = score, networkid = networkid)
+        numOfResults = numOfResults, score = score, networkid = networkid, verbose = verb, endpoint = endpointType, activity = activity)
     }
 
     def trimAddresses (fullAddresses: Seq[AddressResponseAddress]): Seq[AddressResponseAddress] = {
@@ -163,14 +164,14 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
            // removed retrospectively)
             val finalAddresses = if (verb) limitedSortedAddresses else trimAddresses(limitedSortedAddresses)
 
-            addresses.foreach { address =>
-              writeLog(
-                formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
-                score = address.underlyingScore.toString
-              )
-            }
+//            addresses.foreach { address =>
+//              writeLog(
+//                formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
+//                score = address.underlyingScore.toString, activity = "address_response"
+//              )
+//            }
 
-            writeLog()
+            writeLog(activity = "address_request")
 
             jsonOk(
               AddressBySearchResponseContainer(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -48,6 +48,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     val offval = offset.getOrElse(defOffset.toString)
 
     val filterString = classificationfilter.getOrElse("")
+    val endpointType = "partial"
 
     val startDateVal = startDate.getOrElse("")
     val endDateVal = endDate.getOrElse("")
@@ -62,7 +63,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
       case None => false
     }
 
-    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {
+    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
       val responseTime = if (doResponseTime) (System.currentTimeMillis() - startingTime).toString else ""
       val networkid = req.headers.get("authorization").getOrElse("Anon").split("_")(0)
       logger.systemLog(
@@ -71,7 +72,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
         limit = limval, filter = filterString, badRequestMessage = badRequestErrorMessage,
         formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid, startDate = startDateVal, endDate = endDateVal,
-        historical = hist
+        historical = hist, verbose = verb, endpoint = endpointType, activity = activity
       )
     }
 
@@ -106,14 +107,14 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
               AddressResponseAddress.fromHybridAddress(_,verb)
             )
 
-            addresses.foreach { address =>
-              writeLog(
-                formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
-                score = address.underlyingScore.toString
-              )
-            }
+//            addresses.foreach { address =>
+//            writeLog(
+//              formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
+//              score = address.underlyingScore.toString, activity = "address_response"
+//            )
+//          }
 
-            writeLog()
+            writeLog(activity = "address_request")
 
             jsonOk(
               AddressByPartialAddressResponseContainer(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
@@ -47,6 +47,7 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
     val offval = offset.getOrElse(defOffset.toString)
 
     val filterString = classificationfilter.getOrElse("")
+    val endpointType = "postcode"
 
     val startDateVal = startDate.getOrElse("")
     val endDateVal = endDate.getOrElse("")
@@ -61,7 +62,7 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
       case None => false
     }
 
-    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {
+    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
       val responseTime = if (doResponseTime) (System.currentTimeMillis() - startingTime).toString else ""
       val networkid = req.headers.get("authorization").getOrElse("Anon").split("_")(0)
       logger.systemLog(
@@ -70,7 +71,7 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
         limit = limval, filter = filterString, badRequestMessage = badRequestErrorMessage,
         formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid,
-        startDate = startDateVal, endDate = endDateVal, historical = hist
+        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb, endpoint = endpointType, activity = activity
       )
     }
 
@@ -107,14 +108,14 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
               AddressResponseAddress.fromHybridAddress(_,verb)
             )
 
-            addresses.foreach { address =>
-              writeLog(
-                formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
-                score = address.underlyingScore.toString
-              )
-            }
+//            addresses.foreach { address =>
+//              writeLog(
+//                formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
+//                score = address.underlyingScore.toString, activity = "address_response"
+//              )
+//            }
 
-            writeLog()
+            writeLog(activity = "address_request")
 
             jsonOk(
               AddressByPostcodeResponseContainer(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -36,6 +36,8 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
     */
   def uprnQuery(uprn: String, startDate: Option[String] = None, endDate: Option[String] = None, historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
 
+    val endpointType = "uprn"
+
     val hist = historical match {
       case Some(x) => Try(x.toBoolean).getOrElse(true)
       case None => true
@@ -51,14 +53,14 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
 
     val startingTime = System.currentTimeMillis()
 
-    def writeLog(badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = ""): Unit = {
+    def writeLog(badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
       val responseTime = System.currentTimeMillis() - startingTime
       val networkid = req.headers.get("authorization").getOrElse("Anon").split("_")(0)
 
       logger.systemLog(ip = req.remoteAddress, url = req.uri, responseTimeMillis = responseTime.toString,
         uprn = uprn, isNotFound = notFound, formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid,
-        startDate = startDateVal, endDate = endDateVal, historical = hist
+        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb, endpoint = endpointType, activity = activity
       )
     }
 
@@ -88,7 +90,7 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
 
             writeLog(
               formattedOutput = address.formattedAddressNag, numOfResults = "1",
-              score = hybridAddress.score.toString
+              score = hybridAddress.score.toString, activity = "address_request"
             )
 
             jsonOk(

--- a/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
@@ -11,12 +11,12 @@ class AddressAPILogger(log: String) extends APILogger {
 
   def systemLog(ip: String = "", url: String = "", responseTimeMillis: String = "",
     uprn: String = "", postcode: String = "", partialAddress: String = "", input: String = "",
-    offset: String = "", limit: String = "", filter: String = "",
+    offset: String = "", limit: String = "", filter: String = "", verbose: Boolean = false,
     startDate: String = "", endDate: String = "", historical: Boolean = true,
     rangekm: String = "", lat: String = "", lon: String = "", bulkSize: String = "",
     batchSize: String = "", badRequestMessage: String = "", isNotFound: Boolean = false,
     formattedOutput: String = "", numOfResults: String = "", score: String = "",
-    uuid: String = "", networkid: String = ""): Unit = {
+                endpoint: String = "", activity: String = "", uuid: String = "", networkid: String = ""): Unit = {
 
     // Note we are using the info level for Splunk
 
@@ -26,14 +26,14 @@ class AddressAPILogger(log: String) extends APILogger {
           s"is_postcode=${!postcode.isEmpty} is_input=${!input.isEmpty} " +
           s"is_bulk=${!bulkSize.isEmpty} is_partial=${!partialAddress.isEmpty} " +
           s"uprn=$uprn postcode=$postcode input=$input " +
-          s"offset=$offset limit=$limit filter=$filter " +
+          s"offset=$offset limit=$limit filter=$filter " + s"verbose=$verbose " +
           s"partialAddress=$partialAddress " + s"historical=$historical " +
           s"rangekm=$rangekm lat=$lat lon=$lon " +
           s"bulk_size=$bulkSize batch_size=$batchSize " +
           s"bad_request_message=$badRequestMessage is_not_found=$isNotFound " +
-          s"formattedOutput=${formattedOutput.replaceAll("""\s""", "_")}" +
-          s"numOfResults=$numOfResults score=$score " +
-          s"uuid=$uuid networkid=$networkid"
+          s"formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +
+          s"numOfResults=$numOfResults score=$score endpoint=$endpoint " +
+          s"activity=$activity uuid=$uuid networkid=$networkid "
       )
     )
   }


### PR DESCRIPTION
Hides log write out for individual address responses (further work required to convert to trace output).