### PR TITLE
Fix problem with small longitude

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
@@ -116,22 +116,16 @@ object NationalAddressGazetteerAddress {
   def fromEsMap (nag: Map[String, Any]): NationalAddressGazetteerAddress = {
 
     val filteredNag = nag.filter{ case (_, value) => value != null }
-    val matchLocationRegex = """-?\d+\.\d+""".r
+    val matchLocationRegex = """-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?""".r
     val location = filteredNag.getOrElse(Fields.location, "").toString
-    val locationTest = "List(0.0000993, 50.705948)"
-    System.out.println("location = " + location)
     val Array(longitude, latitude) = Try(matchLocationRegex.findAllIn(location).toArray).getOrElse(Array("0", "0"))
 
-    val longString = "0.0000993"
-    System.out.println("set long = " + longString)
-    System.out.println("real long = " + longitude)
     NationalAddressGazetteerAddress (
       uprn = filteredNag.getOrElse(Fields.uprn, "").toString,
       postcodeLocator = filteredNag.getOrElse(Fields.postcodeLocator, "").toString,
       addressBasePostal = filteredNag.getOrElse(Fields.addressBasePostal, "").toString,
       latitude = latitude,
       longitude = longitude,
-   //   longitude = longString,
       easting = filteredNag.getOrElse(Fields.easting, "").toString,
       northing = filteredNag.getOrElse(Fields.northing, "").toString,
       organisation = filteredNag.getOrElse(Fields.organisation, "").toString,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
@@ -118,6 +118,8 @@ object NationalAddressGazetteerAddress {
     val filteredNag = nag.filter{ case (_, value) => value != null }
     val matchLocationRegex = """-?\d+\.\d+""".r
     val location = filteredNag.getOrElse(Fields.location, "").toString
+    val locationTest = "List(0.0000993, 50.705948)"
+    System.out.println("location = " + location)
     val Array(longitude, latitude) = Try(matchLocationRegex.findAllIn(location).toArray).getOrElse(Array("0", "0"))
 
     val longString = "0.0000993"
@@ -128,8 +130,8 @@ object NationalAddressGazetteerAddress {
       postcodeLocator = filteredNag.getOrElse(Fields.postcodeLocator, "").toString,
       addressBasePostal = filteredNag.getOrElse(Fields.addressBasePostal, "").toString,
       latitude = latitude,
-   //   longitude = longitude,
-      longitude = longString,
+      longitude = longitude,
+   //   longitude = longString,
       easting = filteredNag.getOrElse(Fields.easting, "").toString,
       northing = filteredNag.getOrElse(Fields.northing, "").toString,
       organisation = filteredNag.getOrElse(Fields.organisation, "").toString,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
@@ -116,7 +116,7 @@ object NationalAddressGazetteerAddress {
   def fromEsMap (nag: Map[String, Any]): NationalAddressGazetteerAddress = {
 
     val filteredNag = nag.filter{ case (_, value) => value != null }
-    val matchLocationRegex = """-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?""".r
+    val matchLocationRegex = """-?\d+(?:\.\d*)?(?:[E][+\-]?\d+)?""".r
     val location = filteredNag.getOrElse(Fields.location, "").toString
     val Array(longitude, latitude) = Try(matchLocationRegex.findAllIn(location).toArray).getOrElse(Array("0", "0"))
 

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/db/index/NationalAddressGazetteerAddress.scala
@@ -120,12 +120,16 @@ object NationalAddressGazetteerAddress {
     val location = filteredNag.getOrElse(Fields.location, "").toString
     val Array(longitude, latitude) = Try(matchLocationRegex.findAllIn(location).toArray).getOrElse(Array("0", "0"))
 
+    val longString = "0.0000993"
+    System.out.println("set long = " + longString)
+    System.out.println("real long = " + longitude)
     NationalAddressGazetteerAddress (
       uprn = filteredNag.getOrElse(Fields.uprn, "").toString,
       postcodeLocator = filteredNag.getOrElse(Fields.postcodeLocator, "").toString,
       addressBasePostal = filteredNag.getOrElse(Fields.addressBasePostal, "").toString,
       latitude = latitude,
-      longitude = longitude,
+   //   longitude = longitude,
+      longitude = longString,
       easting = filteredNag.getOrElse(Fields.easting, "").toString,
       northing = filteredNag.getOrElse(Fields.northing, "").toString,
       organisation = filteredNag.getOrElse(Fields.organisation, "").toString,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -1,9 +1,7 @@
 package uk.gov.ons.addressIndex.model.server.response.address
 
 import play.api.libs.json._
-//import java.math.BigDecimal
 import scala.math.BigDecimal
-import play.api.libs.functional.syntax._
 import uk.gov.ons.addressIndex.model.db.index.NationalAddressGazetteerAddress
 
 import scala.util.Try
@@ -24,25 +22,7 @@ case class AddressResponseGeo(
 )
 
 object AddressResponseGeo {
-  //implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] = Json.format[AddressResponseGeo]
-
-  val geoReads: Reads[AddressResponseGeo] = (
-      (JsPath \ "latitude").read[BigDecimal] and
-      (JsPath \ "longitude").read[BigDecimal] and
-      (JsPath \ "easting").read[Int] and
-      (JsPath \ "northing").read[Int]
-    )(AddressResponseGeo.apply _)
-
-  val geoWrites: Writes[AddressResponseGeo] = (
-      (JsPath \ "latitide").write[BigDecimal](Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value)))) and
-      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value)))) and
-        //    (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => (JsString(o.bigDecimal.toPlainString)))) and
-      (JsPath \ "easting").write[Int] and
-      (JsPath \ "northing").write[Int]
-    )(unlift(AddressResponseGeo.unapply))
-
-  implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] =
-    Format(geoReads, geoWrites)
+  implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] = Json.format[AddressResponseGeo]
 
   /**
     * Creates GEO information from NAG elastic search object
@@ -51,7 +31,6 @@ object AddressResponseGeo {
     */
   def fromNagAddress(other: NationalAddressGazetteerAddress): Option[AddressResponseGeo] = (for {
       latitude <- Try(BigDecimal(other.latitude))
-   //   longitude <- Try(BigDecimal("0.0000993"))
       longitude <- Try(BigDecimal(other.longitude))
       easting <- Try(other.easting.split("\\.").head.toInt)
       northing <- Try(other.northing.split("\\.").head.toInt)

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -35,7 +35,8 @@ object AddressResponseGeo {
 
   val geoWrites: Writes[AddressResponseGeo] = (
       (JsPath \ "latitide").write[BigDecimal](Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value)))) and
-      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => (JsString(o.bigDecimal.toPlainString)))) and
+      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value)))) and
+        //    (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => (JsString(o.bigDecimal.toPlainString)))) and
       (JsPath \ "easting").write[Int] and
       (JsPath \ "northing").write[Int]
     )(unlift(AddressResponseGeo.unapply))
@@ -50,6 +51,7 @@ object AddressResponseGeo {
     */
   def fromNagAddress(other: NationalAddressGazetteerAddress): Option[AddressResponseGeo] = (for {
       latitude <- Try(BigDecimal(other.latitude))
+     // longitude <- Try(BigDecimal("0.0000093"))
       longitude <- Try(BigDecimal(other.longitude))
       easting <- Try(other.easting.split("\\.").head.toInt)
       northing <- Try(other.northing.split("\\.").head.toInt)

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -1,6 +1,9 @@
 package uk.gov.ons.addressIndex.model.server.response.address
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json._
+//import java.math.BigDecimal
+import scala.math.BigDecimal
+import play.api.libs.functional.syntax._
 import uk.gov.ons.addressIndex.model.db.index.NationalAddressGazetteerAddress
 
 import scala.util.Try
@@ -21,7 +24,24 @@ case class AddressResponseGeo(
 )
 
 object AddressResponseGeo {
-  implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] = Json.format[AddressResponseGeo]
+  //implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] = Json.format[AddressResponseGeo]
+
+  val geoReads: Reads[AddressResponseGeo] = (
+      (JsPath \ "latitude").read[BigDecimal] and
+      (JsPath \ "longitude").read[BigDecimal] and
+      (JsPath \ "easting").read[Int] and
+      (JsPath \ "northing").read[Int]
+    )(AddressResponseGeo.apply _)
+
+  val geoWrites: Writes[AddressResponseGeo] = (
+      (JsPath \ "latitide").write[BigDecimal](Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value.toDouble)))) and
+      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value.toDouble)))) and
+      (JsPath \ "easting").write[Int] and
+      (JsPath \ "northing").write[Int]
+    )(unlift(AddressResponseGeo.unapply))
+
+  implicit lazy val addressResponseGeoFormat: Format[AddressResponseGeo] =
+    Format(geoReads, geoWrites)
 
   /**
     * Creates GEO information from NAG elastic search object

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -51,10 +51,9 @@ object AddressResponseGeo {
     */
   def fromNagAddress(other: NationalAddressGazetteerAddress): Option[AddressResponseGeo] = (for {
       latitude <- Try(BigDecimal(other.latitude))
-     // longitude <- Try(BigDecimal("0.0000093"))
+   //   longitude <- Try(BigDecimal("0.0000993"))
       longitude <- Try(BigDecimal(other.longitude))
       easting <- Try(other.easting.split("\\.").head.toInt)
       northing <- Try(other.northing.split("\\.").head.toInt)
     } yield AddressResponseGeo(latitude, longitude, easting, northing)).toOption
-
 }

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -34,8 +34,8 @@ object AddressResponseGeo {
     )(AddressResponseGeo.apply _)
 
   val geoWrites: Writes[AddressResponseGeo] = (
-      (JsPath \ "latitide").write[BigDecimal](Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value.toDouble)))) and
-      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value.toDouble)))) and
+      (JsPath \ "latitide").write[BigDecimal](Writes((o: BigDecimal) => JsNumber(BigDecimal(JsString(o.bigDecimal.toPlainString).value)))) and
+      (JsPath \ "longitude").write[BigDecimal] (Writes((o: BigDecimal) => (JsString(o.bigDecimal.toPlainString)))) and
       (JsPath \ "easting").write[Int] and
       (JsPath \ "northing").write[Int]
     )(unlift(AddressResponseGeo.unapply))

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -14,8 +14,8 @@ import scala.util.Try
   * @param northing  northing
   */
 case class AddressResponseGeo(
-  latitude: Double,
-  longitude: Double,
+  latitude: BigDecimal,
+  longitude: BigDecimal,
   easting: Int,
   northing: Int
 )
@@ -29,8 +29,8 @@ object AddressResponseGeo {
     * @return
     */
   def fromNagAddress(other: NationalAddressGazetteerAddress): Option[AddressResponseGeo] = (for {
-      latitude <- Try(other.latitude.toDouble)
-      longitude <- Try(other.longitude.toDouble)
+      latitude <- Try(BigDecimal(other.latitude))
+      longitude <- Try(BigDecimal(other.longitude))
       easting <- Try(other.easting.split("\\.").head.toInt)
       northing <- Try(other.northing.split("\\.").head.toInt)
     } yield AddressResponseGeo(latitude, longitude, easting, northing)).toOption

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseGeo.scala
@@ -1,7 +1,6 @@
 package uk.gov.ons.addressIndex.model.server.response.address
 
-import play.api.libs.json._
-import scala.math.BigDecimal
+import play.api.libs.json.{Format, Json}
 import uk.gov.ons.addressIndex.model.db.index.NationalAddressGazetteerAddress
 
 import scala.util.Try

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -219,7 +219,7 @@ addressIndex {
       hybridIndex = ${?ONS_AI_API_HYBRID_INDEX}
 
       hybridIndexHistorical = "hybrid_latest"
-  //    hybridIndexHistorical = "lowertest"
+    // hybridIndexHistorical = "lowertest"
       // hybridIndexHistorical = "hybrid-historical_39_100316_1529495794240"
       // hybridIndexHistorical = "test8h"
       // hybridIndexHistorical = "test3a"

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -213,16 +213,9 @@ addressIndex {
 
     indexes {
       hybridIndex = "hybrid_latest_no_history"
-      // hybridIndex = "hybrid_39_100316_1529494413613"
-      // hybridIndex = "test8"
-      // hybridIndex = "test3a"
       hybridIndex = ${?ONS_AI_API_HYBRID_INDEX}
 
       hybridIndexHistorical = "hybrid_latest"
-    // hybridIndexHistorical = "lowertest"
-      // hybridIndexHistorical = "hybrid-historical_39_100316_1529495794240"
-      // hybridIndexHistorical = "test8h"
-      // hybridIndexHistorical = "test3a"
       hybridIndexHistorical = ${?ONS_AI_API_HYBRID_INDEX_HIST}
       hybridMapping = "address"
       hybridMapping = ${?ONS_AI_API_HYBRID_MAPPING}

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -296,7 +296,7 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
 
     "be creatable (with empty geo field) from Elastic NAG response with invalid longitude" in {
       // Given
-      val nag = givenNag.copy(longitude = "0.0000093")
+      val nag = givenNag.copy(longitude = "invalid")
 
       // When
       val result = AddressResponseGeo.fromNagAddress(nag)

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -296,7 +296,7 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
 
     "be creatable (with empty geo field) from Elastic NAG response with invalid longitude" in {
       // Given
-      val nag = givenNag.copy(longitude = "invalid")
+      val nag = givenNag.copy(longitude = "0.0000093")
 
       // When
       val result = AddressResponseGeo.fromNagAddress(nag)

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -235,8 +235,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       // Given
       val nag = givenRealisticNag
       val expected = Some(AddressResponseGeo(
-        latitude = 50.7341677d,
-        longitude = -3.540302d,
+        latitude = 50.7341677,
+        longitude = -3.540302,
         easting = 291398,
         northing = 93861
       ))
@@ -267,8 +267,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
         paf = Some(expectedPaf),
         nag = Some(expectedNag),
         geo = Some(AddressResponseGeo(
-          latitude = 50.7341677d,
-          longitude = -3.540302d,
+          latitude = 50.7341677,
+          longitude = -3.540302,
           easting = 291398,
           northing = 93861
         )),


### PR DESCRIPTION
Change latitude and longitude from Double to BigDecimal to avoid scientific notation in output.
Modify regex in NationalAddressGazetteer case class to deal with scientific notation in location string.
Played with overriding the JSON serialisation but not needed in  the end.