### PR TITLE
Implement Clusterid feature (REG 2016)

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -23,6 +23,7 @@ case class ElasticSearchConfig(
   connectionRequestTimeout: Int,
   socketTimeout: Int,
   maxESConnections: Int,
+  clusterPolicies: ClusterPoliciesConfig,
   indexes: IndexesConfig,
   queryParams: QueryParamsConfig,
   defaultLimit: Int,
@@ -65,6 +66,16 @@ case class QueryParamsConfig(
 object QueryParamsConfig {
   implicit val queryParamsConfigFormat: Format[QueryParamsConfig] = Json.format[QueryParamsConfig]
 }
+
+// for now each endpoint runs on one cluster, so the values are numbers.
+case class ClusterPoliciesConfig (
+  bulk: String,
+  address: String,
+  partial: String,
+  postcode: String,
+  uprn: String,
+  version: String
+)
 
 case class IndexesConfig(
   hybridIndexHistorical: String,

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -133,7 +133,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(esRepo.queryAddresses(
             tokens, 0, limitExpanded, filterString,
-            rangeVal, latVal, lonVal, startDateVal, endDateVal, None, hist, clusterid)
+            rangeVal, latVal, lonVal, startDateVal, endDateVal, None, hist)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -47,6 +47,8 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
                    matchthreshold: Option[String] = None,
                    verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
 
+    val clusterid = conf.config.elasticSearch.clusterPolicies.address
+
     val startingTime: Long = System.currentTimeMillis()
     val ip: String = req.remoteAddress
     val url: String = req.uri
@@ -131,7 +133,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(esRepo.queryAddresses(
             tokens, 0, limitExpanded, filterString,
-            rangeVal, latVal, lonVal, startDateVal, endDateVal, None, hist)
+            rangeVal, latVal, lonVal, startDateVal, endDateVal, None, hist, clusterid)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/AddressController.scala
@@ -93,7 +93,7 @@ class AddressController @Inject()(val controllerComponents: ControllerComponents
         endDate=endDateVal, startDate = startDateVal, historical = hist, rangekm = rangeVal, lat = latVal, lon = lonVal,
         badRequestMessage = badRequestErrorMessage, formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid, organisation = organisation,
-        verbose = verb, endpoint = endpointType, activity = activity)
+        verbose = verb, endpoint = endpointType, activity = activity, clusterid = clusterid)
     }
 
     def trimAddresses (fullAddresses: Seq[AddressResponseAddress]): Seq[AddressResponseAddress] = {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/BatchController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/BatchController.scala
@@ -285,7 +285,7 @@ class BatchController @Inject()(val controllerComponents: ControllerComponents,
   ): Future[BulkAddresses] = {
 
     val bulkAddresses: Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] = esRepo.queryBulk(
-      inputs, limitperaddress, startDate, endDate, configOverwrite, historical, matchThreshold, includeFullAddress, clusterid
+      inputs, limitperaddress, startDate, endDate, configOverwrite, historical, matchThreshold, includeFullAddress
     )
 
     val successfulAddresses: Future[Stream[Seq[AddressBulkResponseAddress]]] = bulkAddresses.map(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/BatchController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/BatchController.scala
@@ -349,6 +349,7 @@ class BatchController @Inject()(val controllerComponents: ControllerComponents,
     logger.systemLog(
       ip = request.remoteAddress, url = request.uri, responseTimeMillis = responseTime.toString,
       bulkSize = requestData.size.toString, networkid = networkid, organisation = organisation,
+      clusterid = clusterid
     )
 
     response

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
@@ -6,14 +6,15 @@ import com.sksamuel.elastic4s.searches.SearchDefinition
 import javax.inject.Inject
 import play.api.libs.json.Json
 import play.api.mvc._
-import uk.gov.ons.addressIndex.server.modules.{ElasticsearchRepository, ParserModule}
+import uk.gov.ons.addressIndex.server.modules.{ConfigModule, ElasticsearchRepository, ParserModule}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 class DebugController@Inject()(val controllerComponents: ControllerComponents,
   esRepo: ElasticsearchRepository,
-  parser: ParserModule
+  parser: ParserModule,
+  conf: ConfigModule
 )(implicit ec: ExecutionContext) extends BaseController {
 
   implicit object DebugShow extends Show[SearchDefinition]{
@@ -40,6 +41,8 @@ class DebugController@Inject()(val controllerComponents: ControllerComponents,
   def queryDebug(input: String, classificationfilter: Option[String] = None, rangekm: Option[String] = None, lat: Option[String] = None, lon: Option[String] = None, startDate: Option[String], endDate: Option[String], historical: Option[String] = None): Action[AnyContent] = Action { implicit req =>
     val tokens = parser.parse(input)
 
+    val clusterid = conf.config.elasticSearch.clusterPolicies.address
+
     val filterString = classificationfilter.getOrElse("")
     val rangeString = rangekm.getOrElse("")
     val latString = lat.getOrElse("50.705948")
@@ -53,7 +56,7 @@ class DebugController@Inject()(val controllerComponents: ControllerComponents,
       case None => true
     }
 
-    val query = esRepo.generateQueryAddressRequest(tokens,filterString,rangeString,latString,lonString, startDateVal, endDateVal, None, hist)
+    val query = esRepo.generateQueryAddressRequest(tokens,filterString,rangeString,latString,lonString, startDateVal, endDateVal, None, hist, clusterid)
     val showQuery = DebugShow.show(query)
     Ok(Json.parse(showQuery))
   }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/DebugController.scala
@@ -56,7 +56,7 @@ class DebugController@Inject()(val controllerComponents: ControllerComponents,
       case None => true
     }
 
-    val query = esRepo.generateQueryAddressRequest(tokens,filterString,rangeString,latString,lonString, startDateVal, endDateVal, None, hist, clusterid)
+    val query = esRepo.generateQueryAddressRequest(tokens,filterString,rangeString,latString,lonString, startDateVal, endDateVal, None, hist)
     val showQuery = DebugShow.show(query)
     Ok(Json.parse(showQuery))
   }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -40,6 +40,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
     val startingTime = System.currentTimeMillis()
 
+    val clusterid = conf.config.elasticSearch.clusterPolicies.partial
+
     // get the defaults and maxima for the paging parameters from the config
     val defLimit = conf.config.elasticSearch.defaultLimitPartial
     val defOffset = conf.config.elasticSearch.defaultOffset
@@ -101,7 +103,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(
-            esRepo.queryPartialAddress(input, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist)
+            esRepo.queryPartialAddress(input, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist, clusterid)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -77,7 +77,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
         formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid, organisation = organisation,
         startDate = startDateVal, endDate = endDateVal,
-        historical = hist, verbose = verb, endpoint = endpointType, activity = activity
+        historical = hist, verbose = verb, endpoint = endpointType, activity = activity, clusterid = clusterid
       )
     }
 

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -103,7 +103,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(
-            esRepo.queryPartialAddress(input, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist, clusterid)
+            esRepo.queryPartialAddress(input, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
@@ -75,7 +75,8 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
         limit = limval, filter = filterString, badRequestMessage = badRequestErrorMessage,
         formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid, organisation = organisation,
-        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb, endpoint = endpointType, activity = activity
+        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb,
+        endpoint = endpointType, activity = activity, clusterid = clusterid
       )
     }
 

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
@@ -103,7 +103,7 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
 
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(
-            esRepo.queryPostcode(postcode, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist, clusterid)
+            esRepo.queryPostcode(postcode, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PostcodeController.scala
@@ -39,6 +39,8 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
                     historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
     val startingTime = System.currentTimeMillis()
 
+    val clusterid = conf.config.elasticSearch.clusterPolicies.postcode
+
     // get the defaults and maxima for the paging parameters from the config
     val defLimit = conf.config.elasticSearch.defaultLimitPostcode
     val defOffset = conf.config.elasticSearch.defaultOffset
@@ -100,7 +102,7 @@ class PostcodeController @Inject()(val controllerComponents: ControllerComponent
 
         val request: Future[HybridAddresses] =
           overloadProtection.breaker.withCircuitBreaker(
-            esRepo.queryPostcode(postcode, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist)
+            esRepo.queryPostcode(postcode, offsetInt, limitInt, filterString, startDateVal, endDateVal, None, hist, clusterid)
           )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -36,6 +36,8 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
     */
   def uprnQuery(uprn: String, startDate: Option[String] = None, endDate: Option[String] = None, historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
 
+    val clusterid = conf.config.elasticSearch.clusterPolicies.uprn
+
     val endpointType = "uprn"
 
     val hist = historical match {
@@ -82,7 +84,7 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
       case _ =>
 
         val request: Future[Option[HybridAddress]] = overloadProtection.breaker.withCircuitBreaker(
-          esRepo.queryUprn(uprn, startDateVal, endDateVal, hist)
+          esRepo.queryUprn(uprn, startDateVal, endDateVal, hist, clusterid)
         )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -85,7 +85,7 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
       case _ =>
 
         val request: Future[Option[HybridAddress]] = overloadProtection.breaker.withCircuitBreaker(
-          esRepo.queryUprn(uprn, startDateVal, endDateVal, hist, clusterid)
+          esRepo.queryUprn(uprn, startDateVal, endDateVal, hist)
         )
 
         request.map {

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/UPRNController.scala
@@ -64,7 +64,8 @@ class UPRNController @Inject()(val controllerComponents: ControllerComponents,
       logger.systemLog(ip = req.remoteAddress, url = req.uri, responseTimeMillis = responseTime.toString,
         uprn = uprn, isNotFound = notFound, formattedOutput = formattedOutput,
         numOfResults = numOfResults, score = score, networkid = networkid, organisation = organisation,
-        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb, endpoint = endpointType, activity = activity
+        startDate = startDateVal, endDate = endDateVal, historical = hist, verbose = verb,
+        endpoint = endpointType, activity = activity, clusterid = clusterid
       )
     }
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -71,10 +71,19 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       }
     }
 
+
+    val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
+      clusterid + "/" + hybridIndexHistorical.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
+
+    val hybridIndexWithCluster = hybridIndex.split("/")(0) +
+      clusterid + "/" + hybridIndex.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexWithCluster)
+
     if (historical) {
-      search(hybridIndexHistorical + clusterid).query(query)
+      search(hybridIndexHistoricalWithCluster).query(query)
     } else {
-      search(hybridIndex + clusterid).query(query)
+      search(hybridIndexWithCluster).query(query)
     }
   }
 
@@ -282,10 +291,18 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
         }
       }
 
+    val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
+      clusterid + "/" + hybridIndexHistorical.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
+
+    val hybridIndexWithCluster = hybridIndex.split("/")(0) +
+      clusterid + "/" + hybridIndex.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexWithCluster)
+
     if (historical) {
-      search(hybridIndexHistorical + clusterid).query(query)
+      search(hybridIndexHistoricalWithCluster).query(query)
     } else {
-      search(hybridIndex + clusterid).query(query)
+      search(hybridIndexWithCluster).query(query)
     }
   }
 
@@ -352,11 +369,19 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
         }
       }
 
+    val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
+      clusterid + "/" + hybridIndexHistorical.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
+
+    val hybridIndexWithCluster = hybridIndex.split("/")(0) +
+      clusterid + "/" + hybridIndex.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexWithCluster)
+
     if (historical) {
-      search(hybridIndexHistorical + clusterid).query(query)
+      search(hybridIndexHistoricalWithCluster).query(query)
         .sortBy(FieldSortDefinition("lpi.streetDescriptor.keyword").order(SortOrder.ASC), FieldSortDefinition("lpi.paoStartNumber").order(SortOrder.ASC), FieldSortDefinition("lpi.paoStartSuffix.keyword").order(SortOrder.ASC), FieldSortDefinition("uprn").order(SortOrder.ASC))
     } else {
-      search(hybridIndex + clusterid).query(query)
+      search(hybridIndexWithCluster).query(query)
         .sortBy(FieldSortDefinition("lpi.streetDescriptor.keyword").order(SortOrder.ASC), FieldSortDefinition("lpi.paoStartNumber").order(SortOrder.ASC), FieldSortDefinition("lpi.paoStartSuffix.keyword").order(SortOrder.ASC), FieldSortDefinition("uprn").order(SortOrder.ASC))
     }
   }
@@ -870,13 +895,21 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
         should(shouldQueryItr).minimumShouldMatch(queryParams.mainMinimumShouldMatch).filter(termWithGeo ++ Seq(dateQuery).flatten), fallbackQuery)
         .tieBreaker(queryParams.topDisMaxTieBreaker)
 
+    val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
+      clusterid + "/" + hybridIndexHistorical.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
+
+    val hybridIndexWithCluster = hybridIndex.split("/")(0) +
+      clusterid + "/" + hybridIndex.split("/")(1)
+    System.out.println("index with cluster=" + hybridIndexWithCluster)
+
     if (historical) {
-      search(hybridIndexHistorical + clusterid).query(query)
+      search(hybridIndexHistoricalWithCluster).query(query)
         .sortBy(FieldSortDefinition("_score").order(SortOrder.DESC), FieldSortDefinition("uprn").order(SortOrder.ASC))
         .trackScores(true)
         .searchType(SearchType.DfsQueryThenFetch)
     } else {
-      search(hybridIndex + clusterid).query(query)
+      search(hybridIndexWithCluster).query(query)
         .sortBy(FieldSortDefinition("_score").order(SortOrder.DESC), FieldSortDefinition("uprn").order(SortOrder.ASC))
         .trackScores(true)
         .searchType(SearchType.DfsQueryThenFetch)

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -74,11 +74,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
 
     val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
       clusterid + "/" + hybridIndexHistorical.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
 
     val hybridIndexWithCluster = hybridIndex.split("/")(0) +
       clusterid + "/" + hybridIndex.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexWithCluster)
 
     if (historical) {
       search(hybridIndexHistoricalWithCluster).query(query)
@@ -293,11 +291,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
 
     val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
       clusterid + "/" + hybridIndexHistorical.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
 
     val hybridIndexWithCluster = hybridIndex.split("/")(0) +
       clusterid + "/" + hybridIndex.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexWithCluster)
 
     if (historical) {
       search(hybridIndexHistoricalWithCluster).query(query)
@@ -371,11 +367,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
 
     val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
       clusterid + "/" + hybridIndexHistorical.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
 
     val hybridIndexWithCluster = hybridIndex.split("/")(0) +
       clusterid + "/" + hybridIndex.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexWithCluster)
 
     if (historical) {
       search(hybridIndexHistoricalWithCluster).query(query)
@@ -897,11 +891,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
 
     val hybridIndexHistoricalWithCluster = hybridIndexHistorical.split("/")(0) +
       clusterid + "/" + hybridIndexHistorical.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexHistoricalWithCluster)
 
     val hybridIndexWithCluster = hybridIndex.split("/")(0) +
       clusterid + "/" + hybridIndex.split("/")(1)
-    System.out.println("index with cluster=" + hybridIndexWithCluster)
 
     if (historical) {
       search(hybridIndexHistoricalWithCluster).query(query)

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexVersionModule.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexVersionModule.scala
@@ -35,17 +35,17 @@ class AddressIndexVersionModule @Inject()
   // lazy to avoid application crash at startup if ES is down
   lazy val dataVersion: String = {
 
-    val alias: String = configProvider.config.elasticSearch.indexes.hybridIndex
+    val alias: String = configProvider.config.elasticSearch.indexes.hybridIndex + configProvider.config.elasticSearch.clusterPolicies.version
     val aliaseq: Seq[String] = Seq {
       alias
     }
 
-    val requestForIdexes = elasticClientProvider.client.execute {
+    val requestForIndexes = elasticClientProvider.client.execute {
       getAliases(Nil, aliaseq)
     }
 
     // yes, it is blocking, but it only does this request once and there is also timeout in case it goes wrong
-    val indexes: Either[RequestFailure, RequestSuccess[IndexAliases]] = Await.result(requestForIdexes, 10 seconds)
+    val indexes: Either[RequestFailure, RequestSuccess[IndexAliases]] = Await.result(requestForIndexes, 10 seconds)
 
     val index: String = indexes match {
       case Left(l) => l.error.reason

--- a/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
@@ -23,7 +23,7 @@ trait ElasticsearchRepository {
     * @param uprn the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryUprn(uprn: String, startDate: String, endDate:String, historical: Boolean = true, clusterid: String = ""): Future[Option[HybridAddress]]
+  def queryUprn(uprn: String, startDate: String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]]
 
   /**
     * Query the address index by partial address.
@@ -31,7 +31,7 @@ trait ElasticsearchRepository {
     * @param input the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
+  def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
 
   /**
     * Query the address index by postcode.
@@ -39,7 +39,7 @@ trait ElasticsearchRepository {
     * @param postcode the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryPostcode(postcode: String, start: Int, limit: Int, filters: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
+  def queryPostcode(postcode: String, start: Int, limit: Int, filters: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
 
   /**
     * Query the address index for addresses.
@@ -49,7 +49,7 @@ trait ElasticsearchRepository {
     * @param tokens address tokens
     * @return Future with found addresses and the maximum score
     */
-  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, filters: String, range: String, lat: String, lon: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
+  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, filters: String, range: String, lat: String, lon: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, isBulk: Boolean = true): Future[HybridAddresses]
 
   /**
     * Generates request to get address from ES by UPRN
@@ -58,7 +58,7 @@ trait ElasticsearchRepository {
     * @param tokens tokens for the ES query
     * @return Search definition containing query to the ES
     */
-  def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon: String, startDate: String, endDate: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): SearchDefinition
+  def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon: String, startDate: String, endDate: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, isBulk: Boolean = true): SearchDefinition
 
   /**
     * Query ES using MultiSearch endpoint
@@ -68,5 +68,5 @@ trait ElasticsearchRepository {
     * @return a stream of `Either`, `Right` will contain resulting bulk address,
     *         `Left` will contain request data that is to be re-send
     */
-  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, matchThreshold: Float, includeFullAddress: Boolean = false, clusterid: String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]]
+  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, matchThreshold: Float, includeFullAddress: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]]
 }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
@@ -23,7 +23,7 @@ trait ElasticsearchRepository {
     * @param uprn the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryUprn(uprn: String, startDate: String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]]
+  def queryUprn(uprn: String, startDate: String, endDate:String, historical: Boolean = true, clusterid: String = ""): Future[Option[HybridAddress]]
 
   /**
     * Query the address index by partial address.
@@ -31,7 +31,7 @@ trait ElasticsearchRepository {
     * @param input the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
+  def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
 
   /**
     * Query the address index by postcode.
@@ -39,7 +39,7 @@ trait ElasticsearchRepository {
     * @param postcode the identificator of the address
     * @return Future containing a address or `None` if not in the index
     */
-  def queryPostcode(postcode: String, start: Int, limit: Int, filters: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
+  def queryPostcode(postcode: String, start: Int, limit: Int, filters: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
 
   /**
     * Query the address index for addresses.
@@ -49,7 +49,7 @@ trait ElasticsearchRepository {
     * @param tokens address tokens
     * @return Future with found addresses and the maximum score
     */
-  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, filters: String, range: String, lat: String, lon: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
+  def queryAddresses(tokens: Map[String, String], start: Int, limit: Int, filters: String, range: String, lat: String, lon: String, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): Future[HybridAddresses]
 
   /**
     * Generates request to get address from ES by UPRN
@@ -58,7 +58,7 @@ trait ElasticsearchRepository {
     * @param tokens tokens for the ES query
     * @return Search definition containing query to the ES
     */
-  def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon: String, startDate: String, endDate: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): SearchDefinition
+  def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon: String, startDate: String, endDate: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, clusterid: String = ""): SearchDefinition
 
   /**
     * Query ES using MultiSearch endpoint
@@ -68,5 +68,5 @@ trait ElasticsearchRepository {
     * @return a stream of `Either`, `Right` will contain resulting bulk address,
     *         `Left` will contain request data that is to be re-send
     */
-  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, matchThreshold: Float, includeFullAddress: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]]
+  def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String = "", endDate:String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, matchThreshold: Float, includeFullAddress: Boolean = false, clusterid: String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]]
 }

--- a/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
@@ -17,7 +17,7 @@ class AddressAPILogger(log: String) extends APILogger {
     batchSize: String = "", badRequestMessage: String = "", isNotFound: Boolean = false,
     formattedOutput: String = "", numOfResults: String = "", score: String = "",
                 endpoint: String = "", activity: String = "", uuid: String = "",
-                networkid: String = "", organisation: String = ""): Unit = {
+                networkid: String = "", organisation: String = "", clusterid: String = ""): Unit = {
 
     // Note we are using the info level for Splunk
 
@@ -34,7 +34,8 @@ class AddressAPILogger(log: String) extends APILogger {
           s"bad_request_message=$badRequestMessage is_not_found=$isNotFound " +
           s"formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +
           s"numOfResults=$numOfResults score=$score endpoint=$endpoint " +
-          s"activity=$activity uuid=$uuid networkid=$networkid organisation=$organisation "
+          s"activity=$activity uuid=$uuid networkid=$networkid organisation=$organisation " +
+          s"clusterid $clusterid "
       )
     )
   }

--- a/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/utils/AddressAPILogger.scala
@@ -35,7 +35,7 @@ class AddressAPILogger(log: String) extends APILogger {
           s"formattedOutput=${formattedOutput.replaceAll("""\s""", "_")} " +
           s"numOfResults=$numOfResults score=$score endpoint=$endpoint " +
           s"activity=$activity uuid=$uuid networkid=$networkid organisation=$organisation " +
-          s"clusterid $clusterid "
+          s"clusterid=$clusterid "
       )
     )
   }

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -211,6 +211,21 @@ addressIndex {
     circuitBreakerResetTimeout = 30000 // reset the CB and try again time
     circuitBreakerResetTimeout = ${?ONS_AI_API_ES_CB_RESET_TIMEOUT}
 
+    clusterPolicies {
+      bulk = ""
+      bulk = ${?ONS_AI_API_BULK_CLUSTER_NO}
+      address = ""
+      address = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      partial = ""
+      partial = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      postcode = ""
+      postocde = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      uprn = ""
+      uprn = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      version = ""
+      version = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+    }
+
     indexes {
       hybridIndex = "hybrid_latest_no_history"
       hybridIndex = ${?ONS_AI_API_HYBRID_INDEX}

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -149,19 +149,19 @@ class AddressControllerSpec extends PlaySpec with Results {
   // mock that will return one address as a result
   val elasticRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] =
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
       Future.successful(Some(validHybridAddress))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
 
         Future.successful {
           requestsData.map(requestData => {
@@ -176,24 +176,25 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   // mock that won't return any addresses
   val emptyElasticRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] = Future.successful(None)
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
+      Future.successful(None)
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.successful{
         requestsData.map(requestData => {
           val filledBulk = BulkAddress.fromHybridAddress(validHybridAddress, requestData)
@@ -207,22 +208,22 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val sometimesFailingRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] = Future.successful(None)
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] = Future.successful(None)
 
-    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       if (tokens.values.exists(_ == "failed")) Future.failed(new Exception("test failure"))
       else Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.successful {
         requestsData.map {
           case requestData if requestData.tokens.values.exists(_ == "failed") => Left(requestData)
@@ -239,29 +240,29 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val failingRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] =
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
       Future.failed(new Exception("test failure"))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.failed(new Exception("test failure"))
 
-    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.failed(new Exception("test failure"))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
       Future.failed(new Exception("Test exception"))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.failed(new Exception("Test exception"))
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val parser: ParserModule = (_: String) => Map.empty

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -149,19 +149,19 @@ class AddressControllerSpec extends PlaySpec with Results {
   // mock that will return one address as a result
   val elasticRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] =
       Future.successful(Some(validHybridAddress))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
 
         Future.successful {
           requestsData.map(requestData => {
@@ -176,25 +176,25 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   // mock that won't return any addresses
   val emptyElasticRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] =
       Future.successful(None)
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.successful{
         requestsData.map(requestData => {
           val filledBulk = BulkAddress.fromHybridAddress(validHybridAddress, requestData)
@@ -208,22 +208,22 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val sometimesFailingRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] = Future.successful(None)
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] = Future.successful(None)
 
-    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): Future[HybridAddresses] =
       if (tokens.values.exists(_ == "failed")) Future.failed(new Exception("test failure"))
       else Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.successful {
         requestsData.map {
           case requestData if requestData.tokens.values.exists(_ == "failed") => Left(requestData)
@@ -240,29 +240,29 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val failingRepositoryMock: ElasticsearchRepository = new ElasticsearchRepository {
 
-    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true, clusterid:String = ""): Future[Option[HybridAddress]] =
+    override def queryUprn(uprn: String, startDate:String, endDate:String, historical: Boolean = true): Future[Option[HybridAddress]] =
       Future.failed(new Exception("test failure"))
 
-    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.failed(new Exception("test failure"))
 
-    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryPartialAddress(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.failed(new Exception("test failure"))
 
-    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): Future[HybridAddresses] =
+    override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): Future[HybridAddresses] =
       Future.failed(new Exception("Test exception"))
 
-    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false, clusterid:String = ""): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
+    override def queryBulk(requestsData: Stream[BulkAddressRequestData], limit: Int, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, matchThreshold: Float, includeFullAddres: Boolean = false): Future[Stream[Either[BulkAddressRequestData, Seq[AddressBulkResponseAddress]]]] =
       Future.failed(new Exception("Test exception"))
 
     override def queryHealth(): Future[String] = Future.successful("")
 
-    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, clusterid:String = ""): SearchDefinition = SearchDefinition(IndexesAndTypes())
+    override def generateQueryAddressRequest(tokens: Map[String, String], filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): SearchDefinition = SearchDefinition(IndexesAndTypes())
   }
 
   val parser: ParserModule = (_: String) => Map.empty


### PR DESCRIPTION
Each endpoint can now be told which cluster to run on

      bulk = ""
      bulk = ${?ONS_AI_API_BULK_CLUSTER_NO}
      address = ""
      address = ${?ONS_AI_API_LIVE_CLUSTER_NO}

If the Environment variables are not set, everything is as before, but if they are set to 1 or 2 the Gateway will direct Elasticsearch requests to a specific cluster. Tested with bulks on 1, others on 2.