### PR TITLE
Fix Static Code Analysis to show ScalaStyle Results

### DIFF
--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -105,19 +105,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Scapegoat') {
-                    agent { label 'build.sbt_0-13-13' }
-                    steps {
-                        unstash name: 'Checkout'
-                        colourText("info", "Running additional tests")
-                        sh 'sbt "project address-index-server" scapegoat'
-                    }
-                    post {
-                        always {
-                            checkstyle canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'server/target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml', unHealthy: ''
-                        }
-                    }
-                }
             }
             post {
                 success {
@@ -132,7 +119,7 @@ pipeline {
         stage('Publish') {
             agent { label 'build.sbt_0-13-13' }
             when {
-                branch "REG-1843_Build-script-for-new-jenkins"
+                branch "REG-1984_Codacy-static-analysis"
                 // evaluate the when condition before entering this stage's agent, if any
                 beforeAgent true
             }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("com.typesafe.sbt"       %  "sbt-git"               % "0.9.0")
 addSbtPlugin("com.iheart"             %  "sbt-play-swagger"      % "0.6.2-PLAY2.6")
 addSbtPlugin("io.gatling"             %  "gatling-sbt"           % "2.2.2")
 
-addSbtPlugin("org.scalastyle"         %  "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle"         %  "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat"         % "1.0.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
This commit:
 1. Upgrades scalastyle plugin version to the latest 1.0.0
 2. Removes scapeGoat static analysis since the reports generated from
it overwrite the ones created by Scalastyle after which neither are
accessible