### PR TITLE
Fix default encoding being used for Jenkins causing a test failure

### DIFF
--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -62,16 +62,13 @@ pipeline {
                     agent { label 'build.sbt_0-13-13' }
                     steps {
                         unstash name: 'Checkout'
-                        sh 'sbt "project address-index-server" clean compile coverage test coverageReport'
+                        sh 'JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8" sbt "project address-index-server" clean compile coverage test coverageReport'
 
-                        //TODO: Integrate Codacy
-//                        sbt codacyCoverage
-//                        export CODACY_PROJECT_TOKEN=%Project_Token%
                     }
                     post {
                         always {
                             junit '**/server/target/test-reports/*.xml'
-//
+
                             cobertura autoUpdateHealth: false,
                                     autoUpdateStability: false,
                                     coberturaReportFile: 'server/target/**/coverage-report/cobertura.xml',

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -2279,8 +2279,7 @@ class AddressControllerSpec extends PlaySpec with Results {
       actual.toString().substring(0,expectedCodelist.length) mustBe expectedCodelist
     }
 
-    //TODO: resurrect this test
-    "return list of classifications" ignore {
+    "return list of classifications" in {
       // Given
       val expectedCodelist = validClassificationList
       val controller = codelistController


### PR DESCRIPTION
The default encoding being picked up by the JVM on jen-m Jenkins was
causing an error while reading a file containing an accented character.
The default encoding for Travis CI builds (and for local execution of
tests) was UTF-8, however for the Jenkins JVM it was not.

Instead of a code change to specify the encoding which might have impact
elsewhere, I chose to specify the encoding only for the specific SBT
task ('test') which obviates the need to evaluate the impact elswhere.

Task: REG-1985