### PR TITLE
Fix for ES crash due to too many numbers in partial string (REG 2146)

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -247,9 +247,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("best_fields")
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-              matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -257,9 +257,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -269,9 +269,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -280,9 +280,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .matchType("phrase")
                 .slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -292,8 +292,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(1)))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -301,8 +302,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(1)))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -247,9 +247,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("best_fields")
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -257,9 +257,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -269,9 +269,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -280,9 +280,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .matchType("phrase")
                 .slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -292,9 +292,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -302,9 +302,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false).fuzziness("0"),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false).fuzziness("0"))
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -248,7 +248,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               .matchType("best_fields")
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
               .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-              matchQuery("lpi.paoStartNumber",inputNumberList(max(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
+              matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
                 matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -258,7 +258,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               .matchType("phrase").slop(slopVal)
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
               .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                matchQuery("lpi.paoStartNumber",inputNumberList(max(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
                 matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -270,7 +270,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
                 .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(max(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -281,7 +281,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
                 .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(max(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -187,7 +187,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       else None
     }
 
-    val query =
+     val query =
       if (inputNumberList.isEmpty) {
         if (filters.isEmpty) {
           if (fallback) {
@@ -242,14 +242,21 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
         }
       }
       else {
-        if (filters.isEmpty) {
+        val numberQuery =
+          if (inputNumberList.length == 1) {
+            Seq(dismax(Seq(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+              matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))))
+          } else {
+            Seq(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+            matchQuery("lpi.paoStartNumber",inputNumberList(1)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+            matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+          }
+            if (filters.isEmpty) {
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+              .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -257,9 +264,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+              .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -269,9 +274,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+                .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -280,9 +283,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .matchType("phrase")
                 .slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+                .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -292,9 +293,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+                .should(numberQuery)
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -302,9 +301,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
-                  matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
+                .should(numberQuery)
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -247,8 +247,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("best_fields")
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                 matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -257,8 +257,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
               .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+              .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                 matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -269,8 +269,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -280,8 +280,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
                 .matchType("phrase")
                 .slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -292,8 +292,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("best_fields")
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -302,8 +302,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
                 .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
-                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
-                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).fuzzyTranspositions(false),
+                .should(matchQuery("lpi.paoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
+                  matchQuery("lpi.paoStartNumber",inputNumberList(min(1,inputNumberList.length-1))).prefixLength(1).maxExpansions(10).boost(0.5D).fuzzyTranspositions(false),
                   matchQuery("lpi.saoStartNumber",inputNumberList(0)).prefixLength(1).maxExpansions(10).boost(0.2D).fuzzyTranspositions(false))
                 .filter(Seq(Option(termQuery("classificationCode", filterValue)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -752,12 +752,33 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            				}
            			}],
            			"should": [{
-           				"match": {
-           					"lpi.paoStartNumber": {
-           						"query": "4"
-           					}
-           				}
-           			}],
+                     "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "4",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "4",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
            			"filter": [{
            				"prefix": {
            					"classificationCode": {
@@ -806,13 +827,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            					"type": "best_fields"
            				}
            			}],
-           			"should": [{
-           				"match": {
-           					"lpi.paoStartNumber": {
-           						"query": "4"
-           					}
-           				}
-           			}],
+                      			"should": [{
+                                "dis_max": {
+                                  "queries": [
+                                    {
+                                      "match": {
+                                        "lpi.paoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.5,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "match": {
+                                        "lpi.saoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.2,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }],
            			"filter": [{
            				"prefix": {
            					"classificationCode": {
@@ -862,13 +904,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                     "slop":4
            				}
            			}],
-           			"should": [{
-           				"match": {
-           					"lpi.paoStartNumber": {
-           						"query": "4"
-           					}
-           				}
-           			}],
+                      			"should": [{
+                                "dis_max": {
+                                  "queries": [
+                                    {
+                                      "match": {
+                                        "lpi.paoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.5,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "match": {
+                                        "lpi.saoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.2,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }],
            			"filter": [{
            				"prefix": {
            					"classificationCode": {
@@ -961,13 +1024,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            					"type": "best_fields"
            				}
            			}],
-           			"should": [{
-           				"match": {
-           					"lpi.paoStartNumber": {
-           						"query": "4"
-           					}
-           				}
-           			}],
+                      			"should": [{
+                                "dis_max": {
+                                  "queries": [
+                                    {
+                                      "match": {
+                                        "lpi.paoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.5,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "match": {
+                                        "lpi.saoStartNumber": {
+                                          "query": "4",
+                                          "boost": 0.2,
+                                          "fuzzy_transpositions": false,
+                                          "max_expansions": 10,
+                                          "prefix_length": "1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }],
            			"filter": [{
            				"prefix": {
            					"classificationCode": {
@@ -2756,13 +2840,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "slop":4
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+           			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "bool":{
                   "must_not":[{
@@ -2804,13 +2909,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "type":"best_fields"
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+           			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                              "lpi.paoStartNumber": {
+                              "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "bool":{
                   "must_not":[{
@@ -2938,13 +3064,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "slop":4
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+           			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "term":{
                   "classificationCode":{
@@ -2994,13 +3141,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "type":"best_fields"
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+           			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "term":{
                   "classificationCode":{
@@ -3050,13 +3218,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "slop":4
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+           			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "prefix":{
                   "classificationCode":{
@@ -3105,13 +3294,34 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
                   "type":"best_fields"
                 }
               }],
-              "should":[{
-                "match":{
-                  "lpi.paoStartNumber":{
-                    "query":"7"
-                  }
-                }
-              }],
+          			"should": [{
+                      "dis_max": {
+                       "queries": [
+                         {
+                           "match": {
+                             "lpi.paoStartNumber": {
+                               "query": "7",
+                               "boost": 0.5,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         },
+                         {
+                           "match": {
+                             "lpi.saoStartNumber": {
+                               "query": "7",
+                               "boost": 0.2,
+                               "fuzzy_transpositions": false,
+                               "max_expansions": 10,
+                               "prefix_length": "1"
+                             }
+                           }
+                         }
+                       ]
+                     }
+                   }],
               "filter":[{
                 "prefix":{
                   "classificationCode":{


### PR DESCRIPTION
Change to how the house number boost works. Instead of concatenating all the numbers and doing a single match, it now does separate matches on each number "token".

- Crash no longer occurs
- Gatling test shows same or better speed
- Results almost the same, some small differences which initally look like improvements (should do more testing in Test post-merge).