### PR TITLE
Starting address boost (REG-1823 & REG-2311)

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -67,7 +67,7 @@ object QueryParamsConfig {
   implicit val queryParamsConfigFormat: Format[QueryParamsConfig] = Json.format[QueryParamsConfig]
 }
 
-// for now each endpoint runs on one cluster, so the values are numbers.
+// for now each endpoint runs on one cluster, so the values are numbers (1 or 2).
 case class ClusterPoliciesConfig (
   bulk: String,
   address: String,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -38,6 +38,7 @@ case class ElasticSearchConfig(
   circuitBreakerCallTimeout: Int,
   circuitBreakerResetTimeout: Int,
   minimumPartial: Int,
+  defaultStartBoost: Int
 )
 
 case class QueryParamsConfig(

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -42,7 +42,6 @@ case class ElasticSearchConfig(
 )
 
 case class QueryParamsConfig(
-// the number of cases has to be at most 22
   subBuildingName: SubBuildingNameConfig,
   subBuildingRange: SubBuildingRangeConfig,
   buildingName: BuildingNameConfig,

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -72,7 +72,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
     val defStartBoost = conf.config.elasticSearch.defaultStartBoost
 
-    // query string param for testing only
+    // query string param for testing, will probably be removed
     val sboost = startboost match {
       case Some(x) => Try(x.toInt).getOrElse(defStartBoost)
       case None => defStartBoost

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -72,6 +72,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
 
     val defStartBoost = conf.config.elasticSearch.defaultStartBoost
 
+    // query string param for testing only
     val sboost = startboost match {
       case Some(x) => Try(x.toInt).getOrElse(defStartBoost)
       case None => defStartBoost

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -70,9 +70,11 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
       case None => false
     }
 
+    val defStartBoost = conf.config.elasticSearch.defaultStartBoost
+
     val sboost = startboost match {
-      case Some(x) => Try(x.toInt).getOrElse(1)
-      case None => 1
+      case Some(x) => Try(x.toInt).getOrElse(defStartBoost)
+      case None => defStartBoost
     }
 
     logger.warn("sboost = " + sboost)

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -71,8 +71,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     }
 
     val sboost = startboost match {
-      case Some(x) => Try(x.toBoolean).getOrElse(true)
-      case None => true
+      case Some(x) => Try(x.toInt).getOrElse(1)
+      case None => 1
     }
 
     logger.warn("sboost = " + sboost)
@@ -83,12 +83,12 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     }
 
     def boostAddress(add: AddressResponseAddress): AddressResponseAddress =  {
-      logger.warn("input =  " + input.toUpperCase())
-      logger.warn("formatted address = " + add.formattedAddress.toUpperCase())
-      logger.warn("underlying score = " + add.underlyingScore)
-      if (add.formattedAddress.toUpperCase().startsWith(input.toUpperCase())){
-      logger.warn("uprating " + input.toUpperCase())
-      add.copy(underlyingScore = add.underlyingScore + 1F)
+   //   logger.warn("input =  " + input.toUpperCase())
+   //   logger.warn("formatted address = " + add.formattedAddress.toUpperCase())
+    //  logger.warn("underlying score = " + add.underlyingScore)
+      if (add.formattedAddress.toUpperCase().replaceAll("[,]", "").startsWith(input.toUpperCase().replaceAll("[,]", ""))){
+    //  logger.warn("uprating " + input.toUpperCase())
+      add.copy(underlyingScore = add.underlyingScore + sboost)
     } else add.copy(underlyingScore = add.underlyingScore)
     }
 
@@ -140,7 +140,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
               AddressResponseAddress.fromHybridAddressPartial(_,verb)
             )
 
-            val sortAddresses = if (sboost) boostAtStart(addresses) else addresses
+            val sortAddresses = if (sboost > 0) boostAtStart(addresses) else addresses
 
 //            addresses.foreach { address =>
 //            writeLog(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -77,8 +77,6 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
       case None => defStartBoost
     }
 
-    logger.warn("sboost = " + sboost)
-
     def boostAtStart(inAddresses: Seq[AddressResponseAddress]): Seq[AddressResponseAddress] = {
       val boostedAddresses: Seq[AddressResponseAddress] = inAddresses.map {add => boostAddress(add)}
       boostedAddresses.sortBy(_.underlyingScore)(Ordering[Float].reverse)

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -984,6 +984,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
 
       // Successful requests are stored in the `Right`
       // Failed requests will be stored in the `Left`
+      // ignore red line in IntelliJ
       bulkAddressRequest.map(Right(_)).recover {
         case exception: Exception =>
           logger.info(s"#bulk query: rejected request to ES (this might be an indicator of low resource) : ${exception.getMessage}")

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -191,11 +191,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       else None
     }
 
-   // val fieldsToSearch = Seq("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial")
+    val fieldsToSearch = Seq("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial")
 
-    val fieldsToSearch = Seq("lpi.nagAll.partial")
-
-     val query =
+    val query =
       if (inputNumberList.isEmpty) {
         if (filters.isEmpty) {
           if (fallback) {

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -111,6 +111,9 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
   def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, verbose: Boolean = true): Future[HybridAddressesPartial] = {
 
     val request = generateQueryPartialAddressRequest(input, filters, startDate, endDate, queryParamsConfig, historical, false, verbose).start(start).limit(limit)
+    val requestString = SearchBodyBuilderFn(request).string()
+    logger.warn(requestString)
+
     val partResult = client.execute(request).map(HybridAddressesPartial.fromEither)
     // if there are no results for the "phrase" query, delegate to an alternative "best fields" query
     val endResult = partResult.map {adds =>
@@ -194,7 +197,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf"))
+              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial"))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -202,7 +205,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase")
               .slop(slopVal)
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf"))
+              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial"))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -211,7 +214,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -219,7 +222,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase")
                 .slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -228,14 +231,14 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
             else {
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -191,6 +191,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       else None
     }
 
+   // might be faster with less fields search but results worse
     val fieldsToSearch = Seq("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial")
 
     val query =

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -191,13 +191,17 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       else None
     }
 
+   // val fieldsToSearch = Seq("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial")
+
+    val fieldsToSearch = Seq("lpi.nagAll.partial")
+
      val query =
       if (inputNumberList.isEmpty) {
         if (filters.isEmpty) {
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial"))
+              .fields(fieldsToSearch))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -205,7 +209,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase")
               .slop(slopVal)
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial"))
+              .fields(fieldsToSearch))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -214,7 +218,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -222,7 +226,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase")
                 .slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -231,14 +235,14 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
             else {
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -261,7 +265,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
-              .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -269,7 +273,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           else {
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
-              .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -279,7 +283,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -288,7 +292,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase")
                 .slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -298,7 +302,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -306,7 +310,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             else {
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -111,8 +111,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
   def queryPartialAddress(input: String, start: Int, limit: Int, filters: String, startDate: String = "", endDate: String = "", queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, verbose: Boolean = true): Future[HybridAddressesPartial] = {
 
     val request = generateQueryPartialAddressRequest(input, filters, startDate, endDate, queryParamsConfig, historical, false, verbose).start(start).limit(limit)
-    val requestString = SearchBodyBuilderFn(request).string()
-    logger.warn(requestString)
+ //   val requestString = SearchBodyBuilderFn(request).string()
+  //  logger.warn(requestString)
 
     val partResult = client.execute(request).map(HybridAddressesPartial.fromEither)
     // if there are no results for the "phrase" query, delegate to an alternative "best fields" query

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -424,6 +424,8 @@ addressIndex {
     minimumSample = ${?ONS_AI_API_MIN_SAMPLE_SINGLE}
     minimumPartial = 5
     minimumPartial = ${?ONS_AI_API_MIN_PARTIAL_SIZE}
+    defaultStartBoost = 2
+    defaultStartBoost = ${?ONS_AI_API_DEFAULT_START_BOOST}
   }
 
   bulk {

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -83,7 +83,6 @@ play {
             # like peeking mode which "pop".
             task-peeking-mode = "LIFO"
           }
-
         }
       }
       # How long to wait when binding to the listening socket

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -84,7 +84,6 @@ play {
             task-peeking-mode = "LIFO"
           }
 
-
         }
       }
       # How long to wait when binding to the listening socket

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -276,7 +276,7 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
 #    - name: startboost
-#      description: Boost results where the input string appears at the start of the address (0= no boost).
+#      description: Boost results where the input string appears at the start of the address (0 = no boost).
 #      default: 2
 #  responses:
 #    200:
@@ -318,7 +318,7 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
 #    - name: startboost
-#      description: Boost results where the input string appears at the start of the address (0=no boost).
+#      description: Boost results where the input string appears at the start of the address (0 = no boost).
 #      default: 2
 #  responses:
 #    200:

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -276,8 +276,8 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
 #    - name: startboost
-#      description: Boost results where the input string appears at the start of the address.
-#      default: true
+#      description: Boost results where the input string appears at the start of the address (0= no boost).
+#      default: 2
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.
@@ -318,8 +318,8 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
 #    - name: startboost
-#      description: Boost results where the input string appears at the start of the address.
-#      default: true
+#      description: Boost results where the input string appears at the start of the address (0=no boost).
+#      default: 2
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -275,6 +275,9 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #    - name: verbose
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
+#    - name: startboost
+#      description: Boost results where the input string appears at the start of the address.
+#      default: true
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.
@@ -289,7 +292,7 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #    500:
 #      description: Internal server error. Failed to process the request due to an internal error.
 ###
-GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String])
+GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String], startboost: Option[String])
 
 
 ###
@@ -314,6 +317,9 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #    - name: verbose
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
+#    - name: startboost
+#      description: Boost results where the input string appears at the start of the address.
+#      default: true
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.
@@ -328,7 +334,7 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #    500:
 #      description: Internal server error. Failed to process the request due to an internal error.
 ###
-GET     /addresses/partial    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String])
+GET     /addresses/partial    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String], startboost: Option[String])
 
 ###
 #  summary: Search for an address by postcode.

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -244,7 +244,6 @@ class AddressControllerSpec extends PlaySpec with Results {
 
               Right(Seq(emptyBulkAddress))
             }
-
         }
       }
 

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -4504,7 +4504,5 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
       // Then
       result shouldBe expected
     }
-
   }
-
 }

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -746,7 +746,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "phrase",
                     "slop":4
            				}
@@ -823,7 +823,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "best_fields"
            				}
            			}],
@@ -899,7 +899,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "phrase",
                     "slop":4
            				}
@@ -1020,7 +1020,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "best_fields"
            				}
            			}],
@@ -3009,7 +3009,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3079,7 +3079,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3148,7 +3148,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3190,7 +3190,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3233,7 +3233,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3309,7 +3309,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3383,7 +3383,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3460,7 +3460,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3536,7 +3536,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3583,7 +3583,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3629,7 +3629,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3678,7 +3678,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -4505,7 +4505,6 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
       result shouldBe expected
     }
 
-
   }
 
 }


### PR DESCRIPTION
After looking at options to do it in the search query (such as creating a plugin) I ended up doing the boosting in the API code. If the full address starts with the search text, a boost of 0+ points is added to the elastic score. For test purposes this is a query string parameter with a configurable default (currently 2). The query string parameter can be removed once a good setting is determined.

Tests were also done on limiting the fields searched, but there was no obvious big performance hit and we do want to keep the accuracy of checking all versions of the address.