### PR TITLE
Implement startboost function on partial (REG-1823)

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -38,6 +38,7 @@ case class ElasticSearchConfig(
   circuitBreakerCallTimeout: Int,
   circuitBreakerResetTimeout: Int,
   minimumPartial: Int,
+  defaultStartBoost: Int
 )
 
 case class QueryParamsConfig(

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -84,11 +84,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     }
 
     def boostAddress(add: AddressResponseAddress): AddressResponseAddress =  {
-      //   logger.warn("input =  " + input.toUpperCase())
-      //   logger.warn("formatted address = " + add.formattedAddress.toUpperCase())
-      //  logger.warn("underlying score = " + add.underlyingScore)
       if (add.formattedAddress.toUpperCase().replaceAll("[,]", "").startsWith(input.toUpperCase().replaceAll("[,]", ""))){
-        //  logger.warn("uprating " + input.toUpperCase())
         add.copy(underlyingScore = add.underlyingScore + sboost)
       } else add.copy(underlyingScore = add.underlyingScore)
     }

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/PartialAddressController.scala
@@ -38,7 +38,10 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
   def partialAddressQuery(input: String, offset: Option[String] = None, limit: Option[String] = None,
     classificationfilter: Option[String] = None,
     // startDate: Option[String], endDate: Option[String],
-    historical: Option[String] = None, verbose: Option[String] = None): Action[AnyContent] = Action async { implicit req =>
+    historical: Option[String] = None, verbose: Option[String] = None,
+    startboost: Option[String] = None
+  ): Action[AnyContent] = Action async { implicit req =>
+
     val startingTime = System.currentTimeMillis()
 
     val clusterid = conf.config.elasticSearch.clusterPolicies.partial
@@ -66,6 +69,28 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
     val verb = verbose match {
       case Some(x) => Try(x.toBoolean).getOrElse(false)
       case None => false
+    }
+
+    val defStartBoost = conf.config.elasticSearch.defaultStartBoost
+    // query string param for testing, will probably be removed
+    val sboost = startboost match {
+      case Some(x) => Try(x.toInt).getOrElse(defStartBoost)
+      case None => defStartBoost
+    }
+
+    def boostAtStart(inAddresses: Seq[AddressResponseAddress]): Seq[AddressResponseAddress] = {
+      val boostedAddresses: Seq[AddressResponseAddress] = inAddresses.map {add => boostAddress(add)}
+      boostedAddresses.sortBy(_.underlyingScore)(Ordering[Float].reverse)
+    }
+
+    def boostAddress(add: AddressResponseAddress): AddressResponseAddress =  {
+      //   logger.warn("input =  " + input.toUpperCase())
+      //   logger.warn("formatted address = " + add.formattedAddress.toUpperCase())
+      //  logger.warn("underlying score = " + add.underlyingScore)
+      if (add.formattedAddress.toUpperCase().replaceAll("[,]", "").startsWith(input.toUpperCase().replaceAll("[,]", ""))){
+        //  logger.warn("uprating " + input.toUpperCase())
+        add.copy(underlyingScore = add.underlyingScore + sboost)
+      } else add.copy(underlyingScore = add.underlyingScore)
     }
 
     def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
@@ -116,6 +141,8 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
               AddressResponseAddress.fromHybridAddressPartial(_,verb)
             )
 
+            val sortAddresses = if (sboost > 0) boostAtStart(addresses) else addresses
+
 //            addresses.foreach { address =>
 //            writeLog(
 //              formattedOutput = address.formattedAddressNag, numOfResults = total.toString,
@@ -131,7 +158,7 @@ class PartialAddressController @Inject()(val controllerComponents: ControllerCom
                 dataVersion = dataVersion,
                 response = AddressByPartialAddressResponse(
                   input = input,
-                  addresses = addresses,
+                  addresses = sortAddresses,
                   filter = filterString,
                   historical = hist,
                   limit = limitInt,

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -188,13 +188,15 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       else None
     }
 
+    val fieldsToSearch = Seq("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf.partial")
+
      val query =
       if (inputNumberList.isEmpty) {
         if (filters.isEmpty) {
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -202,7 +204,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             must(multiMatchQuery(input)
               .matchType("phrase")
               .slop(slopVal)
-              .fields("lpi.nagAll.partial", "paf.mixedPaf.partial", "paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
           }
@@ -211,7 +213,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -219,7 +221,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase")
                 .slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -228,14 +230,14 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
             else {
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
             }
@@ -258,7 +260,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           if (fallback) {
             must(multiMatchQuery(input)
               .matchType("best_fields")
-              .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -266,7 +268,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
           else {
             must(multiMatchQuery(input)
               .matchType("phrase").slop(slopVal)
-              .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+              .fields(fieldsToSearch))
               .should(numberQuery)
               .filter(Seq(Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                 .flatten)
@@ -276,7 +278,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -285,7 +287,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
               must(multiMatchQuery(input)
                 .matchType("phrase")
                 .slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(prefixQuery("classificationCode", filterValuePrefix)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -295,7 +297,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             if (fallback) {
               must(multiMatchQuery(input)
                 .matchType("best_fields")
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)
@@ -303,7 +305,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
             else {
               must(multiMatchQuery(input)
                 .matchType("phrase").slop(slopVal)
-                .fields("lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"))
+                .fields(fieldsToSearch))
                 .should(numberQuery)
                 .filter(Seq(Option(termsQuery("classificationCode", filterValueTerm)), Option(not(termQuery("lpi.addressBasePostal", "N"))), dateQuery)
                   .flatten)

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -424,6 +424,8 @@ addressIndex {
     minimumSample = ${?ONS_AI_API_MIN_SAMPLE_SINGLE}
     minimumPartial = 5
     minimumPartial = ${?ONS_AI_API_MIN_PARTIAL_SIZE}
+    defaultStartBoost = 2
+    defaultStartBoost = ${?ONS_AI_API_DEFAULT_START_BOOST}
   }
 
   bulk {

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -275,6 +275,9 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #    - name: verbose
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
+#    - name: startboost
+#      description: Boost results where the input string appears at the start of the address (0 = no boost).
+#      default: 2
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.
@@ -289,8 +292,7 @@ GET     /addresses/uprn/:uprn    uk.gov.ons.addressIndex.server.controllers.UPRN
 #    500:
 #      description: Internal server error. Failed to process the request due to an internal error.
 ###
-GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String])
-
+GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String], startboost: Option[String])
 
 ###
 #  summary: Search by partial address (for type ahead).
@@ -314,6 +316,9 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #    - name: verbose
 #      description: Include the full address details in the response (including relatives, crossRefs, paf and nag).
 #      default: false
+#    - name: startboost
+#      description: Boost results where the input string appears at the start of the address (0 = no boost).
+#      default: 2
 #  responses:
 #    200:
 #      description: Success. A json return of matched addresses.
@@ -328,7 +333,7 @@ GET     /addresses/partial/:input    uk.gov.ons.addressIndex.server.controllers.
 #    500:
 #      description: Internal server error. Failed to process the request due to an internal error.
 ###
-GET     /addresses/partial    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String])
+GET     /addresses/partial    uk.gov.ons.addressIndex.server.controllers.PartialAddressController.partialAddressQuery(input, offset: Option[String], limit: Option[String], classificationfilter: Option[String], historical: Option[String], verbose: Option[String], startboost: Option[String])
 
 ###
 #  summary: Search for an address by postcode.

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -746,7 +746,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "phrase",
                     "slop":4
            				}
@@ -823,7 +823,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "best_fields"
            				}
            			}],
@@ -899,7 +899,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "phrase",
                     "slop":4
            				}
@@ -1020,7 +1020,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
            			"must": [{
            				"multi_match": {
            					"query": "h4",
-           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+           					"fields": ["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
            					"type": "best_fields"
            				}
            			}],
@@ -3009,7 +3009,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3079,7 +3079,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3148,7 +3148,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3190,7 +3190,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3233,7 +3233,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3309,7 +3309,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3383,7 +3383,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3460,7 +3460,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"7 Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3536,7 +3536,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3583,7 +3583,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],
@@ -3629,7 +3629,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Re",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"phrase",
                   "slop":4
                 }
@@ -3678,7 +3678,7 @@ class ElasticsearchRepositorySpec extends WordSpec with SearchMatchers with Clas
               "must" : [{
                 "multi_match":{
                   "query":"Gate Ret",
-                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf"],
+                  "fields":["lpi.nagAll.partial","paf.mixedPaf.partial","paf.mixedWelshPaf.partial"],
                   "type":"best_fields"
                 }
               }],


### PR DESCRIPTION
After looking at options to do it in the search query (such as creating a plugin) I ended up doing the boosting in the API code. If the full address starts with the search text, a boost of 0+ points is added to the elastic score. For test purposes this is a query string parameter with a configurable default (currently 2). The query string parameter can be removed once a good setting is determined.

Tests were also done on limiting the fields searched, but there was no obvious big performance hit and we do want to keep the accuracy of checking all versions of the address.