### PR TITLE
Enable Skinny index for Random and make cluster customisable (REG-2363)

### DIFF
--- a/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
@@ -3,7 +3,7 @@ package uk.gov.ons.addressIndex.server.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc._
-import uk.gov.ons.addressIndex.model.db.index.HybridAddresses
+import uk.gov.ons.addressIndex.model.db.index.{HybridAddresses, HybridAddressesPartial}
 import uk.gov.ons.addressIndex.model.server.response.address.{AddressResponseAddress, FailedRequestToEsRandomError, OkAddressResponseStatus}
 import uk.gov.ons.addressIndex.model.server.response.random.{AddressByRandomResponse, AddressByRandomResponseContainer}
 import uk.gov.ons.addressIndex.server.modules._
@@ -86,16 +86,16 @@ class RandomController @Inject()(val controllerComponents: ControllerComponents,
 
       case _ =>
 
-        val request: Future[HybridAddresses] =
+        val request: Future[HybridAddressesPartial] =
           overloadProtection.breaker.withCircuitBreaker(
-            esRepo.queryRandom(filterString, limitInt, None, hist)
+            esRepo.queryRandom(filterString, limitInt, None, hist, verb)
           )
 
         request.map {
-          case HybridAddresses(hybridAddresses, maxScore, total) =>
+          case HybridAddressesPartial(hybridAddresses, maxScore, total) =>
 
             val addresses: Seq[AddressResponseAddress] = hybridAddresses.map(
-              AddressResponseAddress.fromHybridAddress(_,verb)
+              AddressResponseAddress.fromHybridAddressPartial(_,verb)
             )
 
             writeLog(activity = "random_address_request")

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
@@ -37,7 +37,7 @@ class RandomController @Inject()(val controllerComponents: ControllerComponents,
     val startingTime = System.currentTimeMillis()
 
     val clusterid = conf.config.elasticSearch.clusterPolicies.random
-
+    logger.warn("clusterid="+clusterid)
     val defLimit = conf.config.elasticSearch.defaultLimitRandom
 
     val limval = limit.getOrElse(defLimit.toString)
@@ -55,7 +55,7 @@ class RandomController @Inject()(val controllerComponents: ControllerComponents,
       case None => false
     }
 
-    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = "", clusterid: String = ""): Unit = {
+    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
       val responseTime = if (doResponseTime) (System.currentTimeMillis() - startingTime).toString else ""
       val networkid = if (req.headers.get("authorization").getOrElse("Anon").indexOf("+") > 0) req.headers.get("authorization").getOrElse("Anon").split("\\+")(0) else req.headers.get("authorization").getOrElse("Anon").split("_")(0)
       val organisation =  if (req.headers.get("authorization").getOrElse("Anon").indexOf("+") > 0) req.headers.get("authorization").getOrElse("Anon").split("\\+")(0).split("_")(1) else "not set"

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
@@ -37,7 +37,7 @@ class RandomController @Inject()(val controllerComponents: ControllerComponents,
     val startingTime = System.currentTimeMillis()
 
     val clusterid = conf.config.elasticSearch.clusterPolicies.random
-    logger.warn("clusterid="+clusterid)
+
     val defLimit = conf.config.elasticSearch.defaultLimitRandom
 
     val limval = limit.getOrElse(defLimit.toString)

--- a/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/controllers/RandomController.scala
@@ -55,7 +55,7 @@ class RandomController @Inject()(val controllerComponents: ControllerComponents,
       case None => false
     }
 
-    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = ""): Unit = {
+    def writeLog(doResponseTime: Boolean = true, badRequestErrorMessage: String = "", notFound: Boolean = false, formattedOutput: String = "", numOfResults: String = "", score: String = "", activity: String = "", clusterid: String = ""): Unit = {
       val responseTime = if (doResponseTime) (System.currentTimeMillis() - startingTime).toString else ""
       val networkid = if (req.headers.get("authorization").getOrElse("Anon").indexOf("+") > 0) req.headers.get("authorization").getOrElse("Anon").split("\\+")(0) else req.headers.get("authorization").getOrElse("Anon").split("_")(0)
       val organisation =  if (req.headers.get("authorization").getOrElse("Anon").indexOf("+") > 0) req.headers.get("authorization").getOrElse("Anon").split("\\+")(0).split("_")(1) else "not set"

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -43,8 +43,8 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
   private val hybridIndexHistoricalBulk = esConf.indexes.hybridIndexHistorical + esConf.clusterPolicies.bulk + "/" + esConf.indexes.hybridMapping
   private val hybridIndexSkinnyRandom = esConf.indexes.hybridIndexSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
   private val hybridIndexHistoricalSkinnyRandom = esConf.indexes.hybridIndexHistoricalSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
-  private val hybridIndexRandom = esConf.indexes.hybridIndexSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
-  private val hybridIndexHistoricalRandom = esConf.indexes.hybridIndexHistoricalSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
+  private val hybridIndexRandom = esConf.indexes.hybridIndex + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
+  private val hybridIndexHistoricalRandom = esConf.indexes.hybridIndexHistorical + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
 
   private val DATE_FORMAT = "yyyy-MM-dd"
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -41,7 +41,10 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
   private val hybridIndexHistoricalAddress = esConf.indexes.hybridIndexHistorical + esConf.clusterPolicies.address + "/" + esConf.indexes.hybridMapping
   private val hybridIndexBulk = esConf.indexes.hybridIndex + esConf.clusterPolicies.bulk + "/" + esConf.indexes.hybridMapping
   private val hybridIndexHistoricalBulk = esConf.indexes.hybridIndexHistorical + esConf.clusterPolicies.bulk + "/" + esConf.indexes.hybridMapping
-
+  private val hybridIndexSkinnyRandom = esConf.indexes.hybridIndexSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
+  private val hybridIndexHistoricalSkinnyRandom = esConf.indexes.hybridIndexHistoricalSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
+  private val hybridIndexRandom = esConf.indexes.hybridIndexSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
+  private val hybridIndexHistoricalRandom = esConf.indexes.hybridIndexHistoricalSkinny + esConf.clusterPolicies.random + "/" + esConf.indexes.hybridMapping
 
   private val DATE_FORMAT = "yyyy-MM-dd"
 
@@ -403,13 +406,13 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
     }
   }
 
-  def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses] = {
+  def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial] = {
 
-    val request = generateQueryRandomRequest(filters, queryParamsConfig, historical).limit(limit)
+    val request = generateQueryRandomRequest(filters, queryParamsConfig, historical, verbose).limit(limit)
 
     logger.trace(request.toString)
 
-    client.execute(request).map(HybridAddresses.fromEither)
+    client.execute(request).map(HybridAddressesPartial.fromEither)
   }
 
   /**
@@ -418,7 +421,7 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
     *
     * @return Search definition containing query to the ES
     */
-  def generateQueryRandomRequest(filters: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): SearchDefinition = {
+  def generateQueryRandomRequest(filters: String, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, verbose: Boolean = false): SearchDefinition = {
 
     val filterType: String = {
       if (filters == "residential" || filters == "commercial" || filters.endsWith("*")) "prefix"
@@ -435,8 +438,6 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
     val filterValueTerm: Seq[String] = filters.toUpperCase.split(",")
 
     val timestamp: Long = System.currentTimeMillis
-
-//    logger.warn(timestamp.toString)
 
     val query =
 
@@ -455,9 +456,17 @@ class AddressIndexRepository @Inject()(conf: AddressIndexConfigModule,
       }
 
     if (historical) {
-      search(hybridIndexHistoricalPostcode).query(query)
+      if (verbose) {
+        search(hybridIndexHistoricalRandom).query(query)
+      } else {
+        search(hybridIndexHistoricalSkinnyRandom).query(query)
+      }
     } else {
-      search(hybridIndexPostcode).query(query)
+      if (verbose) {
+        search(hybridIndexRandom).query(query)
+      } else {
+        search(hybridIndexSkinnyRandom).query(query)
+      }
     }
   }
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepository.scala
@@ -46,7 +46,7 @@ trait ElasticsearchRepository {
     *
     * @return Future containing an address or `None` if not in the index
     */
-  def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true): Future[HybridAddresses]
+  def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig] = None, historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial]
 
   /**
     * Query the address index for addresses.

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -221,7 +221,7 @@ addressIndex {
       address = ${?ONS_AI_API_ADDRESS_CLUSTER_NO}
       partial = ""
       partial = ${?ONS_AI_API_LIVE_CLUSTER_NO}
-      address = ${?ONS_AI_API_PARTIAL_CLUSTER_NO}
+      partial = ${?ONS_AI_API_PARTIAL_CLUSTER_NO}
       postcode = ""
       postcode = ${?ONS_AI_API_LIVE_CLUSTER_NO}
       postcode = ${?ONS_AI_API_POSTCODE_CLUSTER_NO}

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -212,21 +212,28 @@ addressIndex {
     circuitBreakerResetTimeout = 30000 // reset the CB and try again time
     circuitBreakerResetTimeout = ${?ONS_AI_API_ES_CB_RESET_TIMEOUT}
 
+    // by default bulk and random run on one cluster, the rest on t'other
     clusterPolicies {
       bulk = ""
       bulk = ${?ONS_AI_API_BULK_CLUSTER_NO}
       address = ""
       address = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      address = ${?ONS_AI_API_ADDRESS_CLUSTER_NO}
       partial = ""
       partial = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      address = ${?ONS_AI_API_PARTIAL_CLUSTER_NO}
       postcode = ""
       postcode = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      postcode = ${?ONS_AI_API_POSTCODE_CLUSTER_NO}
       uprn = ""
       uprn = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      uprn = ${?ONS_AI_API_UPRN_CLUSTER_NO}
       version = ""
       version = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      version = ${?ONS_AI_API_VERSION_CLUSTER_NO}
       random = ""
-      random = ${?ONS_AI_API_LIVE_CLUSTER_NO}
+      random = ${?ONS_AI_API_BULK_CLUSTER_NO}
+      random = ${?ONS_AI_API_RANDOM_CLUSTER_NO}
     }
 
     indexes {

--- a/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/controllers/AddressControllerSpec.scala
@@ -164,8 +164,8 @@ class AddressControllerSpec extends PlaySpec with Results {
     override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
-      Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial] =
+      Future.successful(HybridAddressesPartial(Seq(validHybridAddressPartial), 1.0f, 1))
 
     override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = true): Future[HybridAddressesPartial] =
       Future.successful(HybridAddressesPartial(Seq(validHybridAddressPartial), 1.0f, 1))
@@ -200,8 +200,8 @@ class AddressControllerSpec extends PlaySpec with Results {
     override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
 
-    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
-      Future.successful(HybridAddresses(Seq.empty, 1.0f, 0))
+    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial] =
+      Future.successful(HybridAddressesPartial(Seq.empty, 1.0f, 0))
 
     override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = true): Future[HybridAddressesPartial] =
       Future.successful(HybridAddressesPartial(Seq.empty, 1.0f, 0))
@@ -236,7 +236,7 @@ class AddressControllerSpec extends PlaySpec with Results {
 
     override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
 
-    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] = Future.successful(HybridAddresses(Seq(validHybridAddress), 1.0f, 1))
+    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial] = Future.successful(HybridAddressesPartial(Seq(validHybridAddressPartial), 1.0f, 1))
 
     override def queryAddresses(tokens: Map[String, String], start:Int, limit: Int, filters: String, range: String, lat: String, lon:String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, isBulk: Boolean = false): Future[HybridAddresses] =
       if (tokens.values.exists(_ == "failed")) Future.failed(new Exception("test failure"))
@@ -271,7 +271,7 @@ class AddressControllerSpec extends PlaySpec with Results {
     override def queryPostcode(postcode: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
       Future.failed(new Exception("test failure"))
 
-    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true): Future[HybridAddresses] =
+    override def queryRandom(filters: String, limit: Int, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = false): Future[HybridAddressesPartial] =
       Future.failed(new Exception("test failure"))
 
     override def queryPartialAddress(input: String, start:Int, limit: Int, filters: String, startDate:String, endDate:String, queryParamsConfig: Option[QueryParamsConfig], historical: Boolean = true, verbose: Boolean = true): Future[HybridAddressesPartial] =
@@ -501,7 +501,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         apiVersion = apiVersionExpected,
         dataVersion = dataVersionExpected,
         response = AddressByRandomResponse(
-          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, false)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddressPartial(validHybridAddressPartial, false)),
           filter = "",
           historical = true,
           limit = 1,
@@ -528,7 +528,7 @@ class AddressControllerSpec extends PlaySpec with Results {
         apiVersion = apiVersionExpected,
         dataVersion = dataVersionExpected,
         response = AddressByRandomResponse(
-          addresses = Seq(AddressResponseAddress.fromHybridAddress(validHybridAddress, true)),
+          addresses = Seq(AddressResponseAddress.fromHybridAddressPartial(validHybridAddressPartial, true)),
           filter = "",
           historical = true,
           limit = 1,


### PR DESCRIPTION
verbose = false runs on skinny
cluster id can be explicitly set in Jenkins or allowed to default to the bulk setting.