### PR TITLE
Add organisation name to RH UPRN output

### DIFF
--- a/api-definitions/ai-swagger.json
+++ b/api-definitions/ai-swagger.json
@@ -2222,6 +2222,9 @@
 				},
 				"countryCode": {
 					"type": "string"
+				},
+				"organisationName": {
+					"type": "string"
 				}
 			},
 			"required": [
@@ -2235,7 +2238,8 @@
 				"foundAddressType",
 				"censusAddressType",
 				"censusEstabType",
-				"countryCode"
+				"countryCode",
+				"organisationName"
 			]
 		},
 		"uk.gov.ons.addressIndex.model.server.response.rh.AddressByRHUprnResponse": {

--- a/api-definitions/explore-the-api/rh/uprn/readme.md
+++ b/api-definitions/explore-the-api/rh/uprn/readme.md
@@ -98,7 +98,8 @@
       "postcode": "EX1 1LL",
       "censusAddressType": "NA",
       "censusEstabType": "NA",
-      "countryCode": "E"
+      "countryCode": "E",
+      "organisationName: "Costa Coffee"
     },
     "addressType": "NAG",
     "historical": true,

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddressUPRNRH.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/address/AddressResponseAddressUPRNRH.scala
@@ -26,7 +26,8 @@ case class AddressResponseAddressUPRNRH(uprn: String,
                                         foundAddressType: String,
                                         censusAddressType: String,
                                         censusEstabType: String,
-                                        countryCode:String)
+                                        countryCode:String,
+                                        organisationName: String)
 
 object AddressResponseAddressUPRNRH {
   implicit lazy val addressResponseAddressUPRNRHFormat: Format[AddressResponseAddressUPRNRH] = Json.format[AddressResponseAddressUPRNRH]

--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/rh/AddressByRHUprnResponse.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/server/response/rh/AddressByRHUprnResponse.scala
@@ -84,6 +84,29 @@ object AddressByRHUprnResponse {
       }
     }
 
+    val organisationName = foundAddressType match {
+      case AddressTypes.paf => chosenPaf match {
+        case Some(pafAddress) => pafAddress.organisationName
+        case None => ""
+      }
+      case AddressTypes.welshPaf => chosenPaf match {
+        case Some(pafAddress) => pafAddress.organisationName
+        case None => ""
+      }
+      case AddressTypes.nag => chosenNag match {
+        case Some(nagAddress) => nagAddress.organisation
+        case None => ""
+      }
+      case AddressTypes.welshNag => chosenWelshNag match {
+        case Some(nagAddress) => nagAddress.organisation
+        case None => ""
+      }
+      case AddressTypes.nisra => chosenNisra match {
+        case Some(nisraAddress) => nisraAddress.organisationName
+        case None => ""
+      }
+    }
+
     val postcode = foundAddressType match {
       case AddressTypes.paf | AddressTypes.welshPaf => chosenPaf match {
         case Some(pafAddress) => pafAddress.postcode
@@ -116,7 +139,8 @@ object AddressByRHUprnResponse {
       foundAddressType = foundAddressType,
       censusAddressType = other.censusAddressType,
       censusEstabType = other.censusEstabType,
-      countryCode = other.countryCode
+      countryCode = other.countryCode,
+      organisationName = organisationName
     )
   }
 

--- a/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/model/response/AddressResponseAddressSpec.scala
@@ -1211,7 +1211,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       foundAddressType="PAF",
       censusAddressType = "NA",
       censusEstabType="NA",
-      countryCode = "E"
+      countryCode = "E",
+      organisationName = "6"
     )
 
     // When
@@ -1236,7 +1237,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       foundAddressType="WELSHPAF",
       censusAddressType = "NA",
       censusEstabType="NA",
-      countryCode = "W"
+      countryCode = "W",
+      organisationName = "6"
     )
 
     // When
@@ -1261,7 +1263,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       foundAddressType = "NAG",
       censusAddressType = "NA",
       censusEstabType = "NA",
-      countryCode = "E"
+      countryCode = "E",
+      organisationName = "n22"
     )
 
     // When
@@ -1286,7 +1289,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       foundAddressType="WELSHNAG",
       censusAddressType = "NA",
       censusEstabType="NA",
-      countryCode = "W"
+      countryCode = "W",
+      organisationName = "n22"
     )
 
     // When
@@ -1311,7 +1315,8 @@ class AddressResponseAddressSpec extends WordSpec with Matchers {
       foundAddressType="NISRA",
       censusAddressType = "NA",
       censusEstabType="NA",
-      countryCode = "E"
+      countryCode = "E",
+      organisationName = "1"
     )
 
     // When


### PR DESCRIPTION
Returns the organisation name from the PAF or NAG record according to preference order.
Does not require an index change because UPRN always runs on the fat index on GCP.