### PR TITLE
Change single match scale factor to match on-prem

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -494,7 +494,7 @@ addressIndex {
     minimumFallback = ${?ONS_AI_API_MIN_FALLBACK_SIZE}
     defaultStartBoost = 8
     defaultStartBoost = ${?ONS_AI_API_DEFAULT_START_BOOST}
-    scaleFactor = 11
+    scaleFactor = 21
     scaleFactor = ${?ONS_AI_API_SCALE_FACTOR}
   }
 
@@ -502,7 +502,7 @@ addressIndex {
     batch {
       perBatch = 500
       perBatch = ${?ONS_AI_API_BULK_REQUESTS_PER_BATCH}
-      perBatchLimit = 2000
+      perBatchLimit = 1300
       perBatchLimit = ${?ONS_AI_API_MAX_BULK_REQUESTS_PER_BATCH}
       upscale = 1.1
       upscale = ${?ONS_AI_API_BULK_REQUESTS_MINI_BATCH_UPSCALE}


### PR DESCRIPTION
ONS_AI_API_SCALE_FACTOR is for singles and we lowered this for CC (aux results)

ONS_AI_API_BULK_SCALE_FACTOR is the bulk setting and this is set to 23 

Whilst the JIRA ticket to tune the scale factor(s) is still outstanding, a figure of 21 has been working well on the single matches (mainly via UI) on-prem so we want to restore this to the default for GCP deployments.