### PR TITLE
Boost scores of addresses that can receive post 

### DIFF
--- a/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
+++ b/model/src/main/scala/uk/gov/ons/addressIndex/model/config/AddressIndexConfig.scala
@@ -70,6 +70,7 @@ case class QueryParamsConfig(// the number of cases has to be at most 22
                              locality: LocalityConfig,
                              fallback: FallbackConfig,
                              nisra: NisraConfig,
+                             postal: PostalConfig,
                              excludingDisMaxTieBreaker: Double,
                              includingDisMaxTieBreaker: Double,
                              topDisMaxTieBreaker: Double,
@@ -227,6 +228,14 @@ case class NisraConfig (partialNiBoostBoost: Double,
 
 object NisraConfig {
   implicit val NisraConfigFormat: Format[NisraConfig] = Json.format[NisraConfig]
+}
+
+case class PostalConfig ( postalDBoost: Double,
+                          postalCBoost: Double,
+                          postalLBoost: Double)
+
+object PostalConfig {
+  implicit val PostalConfigFormat: Format[PostalConfig] = Json.format[PostalConfig]
 }
 
 

--- a/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
+++ b/server/app/uk/gov/ons/addressIndex/server/modules/AddressIndexRepository.scala
@@ -407,24 +407,20 @@ class AddressIndexRepository @Inject()(conf: ConfigModule,
  //   C = A record which is postal and has a parent record which is linked to PAF
  //   L = A record which is identified as postal based on Local Authority information
 
-    val postalDBoost = 2
-    val postalCBoost = 1
-    val postalLBoost = 1
-
     val postalQuery =
       Seq(
         constantScoreQuery(matchQuery(
           field = "lpi.addressBasePostal",
           value = "D"
-        )).boost(postalDBoost),
+        )).boost(queryParams.postal.postalDBoost),
         constantScoreQuery(matchQuery(
           field = "lpi.addressBasePostal",
           value = "C"
-        )).boost(postalCBoost),
+        )).boost(queryParams.postal.postalCBoost),
         constantScoreQuery(matchQuery(
           field = "lpi.addressBasePostal",
           value = "L"
-        )).boost(postalLBoost)
+        )).boost(queryParams.postal.postalLBoost)
       )
 
     // this part of query should be blank unless there is an end number or end suffix
@@ -1103,8 +1099,8 @@ class AddressIndexRepository @Inject()(conf: ConfigModule,
   override def runMultiResultQuery(args: MultiResultArgs): Future[HybridAddressCollection] = {
     val query = makeQuery(args)
  // uncomment to see generated query
-    val searchString = SearchBodyBuilderFn(query).string()
-    println(searchString)
+ //   val searchString = SearchBodyBuilderFn(query).string()
+  //  println(searchString)
     args match {
       case partialArgs: PartialArgs =>
         val minimumFallback: Int = esConf.minimumFallback

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -459,6 +459,15 @@ addressIndex {
         fullFallBackBigramNiBoost = ${?ONS_AI_API_QUERY_NISRA_FALLBACK_NI_BIGRAM_BOOST}
       }
 
+      postal {
+        postalDBoost = 1.2
+        postalDBoost  = ${?ONS_AI_API_QUERY_POSTAL_D_BOOST}
+        postalCBoost = 1.1
+        postalCBoost  = ${?ONS_AI_API_QUERY_POSTAL_C_BOOST}
+        postalLBoost = 1.1
+        postalLBoost  = ${?ONS_AI_API_QUERY_POSTAL_L_BOOST}
+      }
+
       excludingDisMaxTieBreaker = 0.0
       excludingDisMaxTieBreaker = ${?ONS_AI_API_QUERY_EXCLUDING_TIE_BREAKER_BOOST}
       includingDisMaxTieBreaker = 0.5

--- a/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
+++ b/server/test/uk/gov/ons/addressIndex/server/modules/ElasticsearchRepositorySpec.scala
@@ -144,27 +144,6 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
   val hybridNagCustCode: String = "1110"
   val hybridNagCustName: String = "Exeter"
 
-  val hybridMixedNisra = "mixedNisra"
-  val hybridNisraOrganisationName: String = hybridPafOrganisationName
-  val hybridNisraSubBuildingName: String = hybridPafSubBuildingName
-  val hybridNisraBuildingName: String = hybridPafBuildingName
-  val hybridNisraBuildingNumber = "h26"
-  val hybridNisraThoroughfare: String = hybridPafThoroughfare
-  val hybridNisraAltThoroughfare = "h27"
-  val hybridNisraDependentThoroughfare = "h28"
-  val hybridNisraLocality = "h29"
-  val hybridNisraTownland = "h30"
-  val hybridNisraTownName = "h31"
-  val hybridNisraPostcode = "h32"
-  val hybridNisraUprn = "h25"
-  val hybridNisraPostTown = "h33"
-  val hybridNisraEasting = "h21"
-  val hybridNisraNorthing = "h22"
-  val hybridNisraLatitude = "h23"
-  val hybridNisraLongitude = "h24"
-  val hybridNisraLocalCouncil = "BELFAST"
-  val hybridNisraLGDCode = "N09000003"
-
   val hybridNagCustGeogCode = "E07000041"
   val hybridStartDate = "2013-01-01"
   val hybridEndDate = "2014-01-01"
@@ -620,46 +599,6 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
   )
 
-  val expectedNisra: NisraAddress = NisraAddress(
-    hybridNisraOrganisationName,
-    hybridNisraSubBuildingName,
-    hybridNisraBuildingName,
-    hybridNisraBuildingNumber,
-    Nil,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNisraThoroughfare,
-    hybridNisraAltThoroughfare,
-    hybridNisraDependentThoroughfare,
-    hybridNisraLocality,
-    hybridNisraTownName,
-    hybridNisraPostcode,
-    hybridNisraUprn,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNisraPostTown,
-    hybridNisraEasting,
-    hybridNisraNorthing,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNisraLatitude,
-    hybridNisraLongitude,
-    hybridNotUsed,
-    hybridNotUsed,
-    hybridNisraLocalCouncil,
-    hybridNisraLGDCode,
-    hybridMixedNisra
-  )
-
   val expectedDateNag: NationalAddressGazetteerAddress = expectedNag.copy(
     uprn = hybridFirstDateUprn.toString,
     lpiStartDate = hybridStartDate,
@@ -841,7 +780,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
       val repository = new AddressIndexRepository(config, elasticClientProvider)
       val expected = Json.parse(
         s"""
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"h4","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"H4","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"h4","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"H4","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """.stripMargin
       )
 
@@ -863,7 +802,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
       val repository = new AddressIndexRepository(config, elasticClientProvider)
       val expected = Json.parse(
         s"""
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"12345","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"12345","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"12345","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"12345","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"12345","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"12345","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"12345","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"12345","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"12345","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"12345","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"12345","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"12345","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"12345","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"12345","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"12345","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"12345","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"12345","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """.stripMargin
       )
 
@@ -885,7 +824,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
       val repository = new AddressIndexRepository(config, elasticClientProvider)
       val expected = Json.parse(
         s"""
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"123456","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"123456","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"123456","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"123456","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"123456","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"123456","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"123456","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"123456","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"123456","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"123456","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"123456","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """.stripMargin
       )
 
@@ -907,7 +846,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
       val repository = new AddressIndexRepository(config, elasticClientProvider)
       val expected = Json.parse(
         s"""
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"h4","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"H4","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"h4","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"H4","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"H4","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """.stripMargin
       )
 
@@ -949,7 +888,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
       val repository = new AddressIndexRepository(config, elasticClientProvider)
       val expected = Json.parse(
         s"""
-          {"query":{"bool":{"must":[{"bool":{"must":[{"term":{"postcode":{"value":" H4"}}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}}]}},"from":0,"size":1,"sort":[{"lpi.streetDescriptor.keyword":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.thoroughfare.keyword":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}]}
+          {"query":{"bool":{"must":[{"bool":{"must":[{"term":{"postcode":{"value":" H4"}}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}}]}},"from":0,"size":1,"sort":[{"lpi.streetDescriptor.keyword":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}]}
          """.stripMargin
       )
 
@@ -1056,104 +995,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                      "query":"",
-                      "analyzer":"welsh_split_synonyms_analyzer",
-                      "boost":${queryParams.fallback.fallbackPafBoost},
-                      "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                    }
-                  }
-                  },{
-                    "match":{
-                      "paf.pafAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                          "query":"",
-                            "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                            "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      }]
-                    }
-                  }],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+           {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1199,8 +1041,8 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h16"}}},"boost":1}}]}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.streetName":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"nisra.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.welshThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"nisra.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"nisra.altThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.streetDescriptor":{"query":"h7","fuzziness":"1"}}},"boost":2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.postcodeLocator":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"postcodeOut":{"query":"h02p","fuzziness":"1"}}},{"match":{"postcodeIn":{"query":"h01p","fuzziness":"2"}}}]}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"paf.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"nisra.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h5","fuzziness":"1","minimum_should_match":"-45%"}}},"boost":2.5}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"lpi.paoStartNumber":{"query":"13"}}},{"match":{"lpi.paoStartSuffix":{"query":"h11"}}}]}},"boost":3}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"dis_max":{"tie_breaker":0,"boost":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.paoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h11"}}},"boost":1}}]}}]}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.organisation":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h3","minimum_should_match":"30%"}}},"boost":0.5}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"nisra.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"nisra.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"13"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartSuffix":{"query":"h11"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndNumber":{"query":"12"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndSuffix":{"query":"h14"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"nisra.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"nisra.paoStartNumber":{"query":"13"}}},"boost":0.1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndNumber":{"query":"17"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"17"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"token.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}}]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"nisra.nisraAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"nisra.nisraAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}}]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
-         """.stripMargin)
+          {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h16"}}},"boost":1}}]}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.streetName":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.welshThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.streetDescriptor":{"query":"h7","fuzziness":"1"}}},"boost":2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.postcodeLocator":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"postcodeOut":{"query":"h02p","fuzziness":"1"}}},{"match":{"postcodeIn":{"query":"h01p","fuzziness":"2"}}}]}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"paf.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h5","fuzziness":"1","minimum_should_match":"-45%"}}},"boost":2.5}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"lpi.paoStartNumber":{"query":"13"}}},{"match":{"lpi.paoStartSuffix":{"query":"h11"}}}]}},"boost":3}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"dis_max":{"tie_breaker":0,"boost":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.paoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h11"}}},"boost":1}}]}}]}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.organisation":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h3","minimum_should_match":"30%"}}},"boost":0.5}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"13"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartSuffix":{"query":"h11"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndNumber":{"query":"12"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndSuffix":{"query":"h14"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"13"}}},"boost":0.1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndNumber":{"query":"17"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"17"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"token.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}}]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
+        """.stripMargin)
 
       // When
       val args = AddressArgs(
@@ -1305,105 +1147,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                 "match":{
-                   "paf.pafAll":{
-                     "query":"",
-                     "analyzer":"welsh_split_synonyms_analyzer",
-                     "boost":${queryParams.fallback.fallbackPafBoost},
-                     "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                     }
-                   }
-                 }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      }]
-                    }
-                  }],
-                  "filter": [{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+           {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1431,113 +1175,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "paf.pafAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                         "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      }]
-                    }
-                  }],
-                  "filter": [
-                    {
-                      "prefix": {
-                        "classificationCode": {
-                          "value": "C"
-                        }
-                      }
-                    }
-                  ],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+          {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"prefix":{"classificationCode":{"value":"C"}}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"prefix":{"classificationCode":{"value":"C"}}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1565,111 +1203,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "paf.pafAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                       }
-                      }]
-                    }
-                  }],
-                  "filter": [
-                    {
-                      "terms": {
-                        "classificationCode": ["RD06"]
-                      }
-                    }
-                  ],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+           {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1697,111 +1231,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "paf.pafAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      }]
-                    }
-                  }],
-                  "filter": [
-                    {
-                      "terms": {
-                        "classificationCode": ["RD06","RD"]
-                      }
-                    }
-                  ],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+           {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"terms":{"classificationCode":["RD06","RD"]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"terms":{"classificationCode":["RD06","RD"]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1829,111 +1259,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         s"""
-          {
-
-            "query":{
-              "bool":{
-                "must":[{
-                  "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackAuxBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "lpi.nagAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackLpiBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "nisra.nisraAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  },{
-                    "match":{
-                      "paf.pafAll":{
-                        "query":"",
-                        "analyzer":"welsh_split_synonyms_analyzer",
-                        "boost":${queryParams.fallback.fallbackPafBoost},
-                        "minimum_should_match":"${queryParams.fallback.fallbackMinimumShouldMatch}"
-                      }
-                    }
-                  }]
-                }
-              }],
-              "should":[{
-                "dis_max":{
-                  "tie_breaker":0,
-                  "queries":[{
-                    "match":{
-                      "tokens.addressAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackAuxBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                    "match":{
-                      "lpi.nagAll.bigram":{
-                        "query":"",
-                          "boost":${queryParams.fallback.fallbackLpiBigramBoost},
-                          "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                        }
-                      }
-                    },{
-                      "match":{
-                        "nisra.nisraAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      },{
-                      "match":{
-                        "paf.pafAll.bigram":{
-                          "query":"",
-                           "boost":${queryParams.fallback.fallbackPafBigramBoost},
-                           "fuzziness":"${queryParams.fallback.bigramFuzziness}"
-                          }
-                        }
-                      }]
-                    }
-                  }],
-                  "filter": [
-                    {
-                      "terms": {
-                        "classificationCode": ["RD*","RD02"]
-                      }
-                    }
-                  ],
-                  "boost":0.5
-                }
-              },
-              "from": 0,
-              "size": 1,
-              "sort":[{
-                "_score":{
-                  "order":"desc"
-                }
-              },{
-                "uprn":{"order":"asc"}
-            }],
-            "track_scores":true
-          }
+           {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"terms":{"classificationCode":["RD*","RD02"]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"terms":{"classificationCode":["RD*","RD02"]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When
@@ -1957,7 +1283,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Re","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
          """
       )
 
@@ -1979,8 +1305,8 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Ret","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
-           """
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+         """
       )
 
       // When
@@ -2002,7 +1328,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Re","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2024,7 +1350,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Ret","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}}]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2048,7 +1374,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Re","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2072,7 +1398,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Ret","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+            {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2095,7 +1421,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Re","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+            {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Re","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
           """
       )
 
@@ -2117,7 +1443,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"nisra.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"7 Gate Ret","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"7 Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"match":{"lpi.paoStartNumber":{"query":"7","boost":2,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}},{"match":{"lpi.saoStartNumber":{"query":"7","boost":1,"fuzzy_transpositions":false,"max_expansions":10,"prefix_length":"1"}}}]}},{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"7 Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"7 Gate Ret","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2140,7 +1466,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Re","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2162,7 +1488,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Ret","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}}]}}],"filter":[{"terms":{"classificationCode":["RD"]}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
          """
       )
 
@@ -2185,7 +1511,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Re","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+          {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Re","fields":["mixedPartial"],"type":"phrase","slop":25}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Re","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Re","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
         """
       )
 
@@ -2207,7 +1533,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse(
         """
-           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"nisra.mixedNisraStart":{"value":"Gate Ret","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"nisra.paoStartNumber":{"order":"asc"}},{"nisra.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
+           {"timeout":"250ms","query":{"function_score":{"query":{"bool":{"must":[{"multi_match":{"query":"Gate Ret","fields":["mixedPartial"],"type":"best_fields"}}],"should":[{"dis_max":{"queries":[{"prefix":{"lpi.mixedNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"lpi.mixedWelshNagStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedPafStart":{"value":"Gate Ret","boost":1.25}}},{"prefix":{"paf.mixedWelshPafStart":{"value":"Gate Ret","boost":1.25}}}]}}],"filter":[{"bool":{"should":[{"prefix":{"classificationCode":{"value":"RD"}}},{"prefix":{"classificationCode":{"value":"RH"}}},{"prefix":{"classificationCode":{"value":"RI"}}}],"minimum_should_match":"1"}}]}},"min_score":1,"boost_mode":"replace","functions":[{"script_score":{"script":{"source":"Math.round(_score/1.8)"}}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"postcodeStreetTown":{"order":"asc"}},{"lpi.paoStartNumber":{"order":"asc"}},{"lpi.paoStartSuffix.keyword":{"order":"asc"}},{"lpi.secondarySort":{"order":"asc"}},{"uprn":{"order":"asc"}}],"highlight":{"number_of_fragments":0,"fields":{"mixedPartial":{}}}}
          """
       )
 
@@ -2254,7 +1580,7 @@ class ElasticsearchRepositorySpec extends AnyWordSpec with should.Matchers with 
 
       val expected = Json.parse (
         s"""
-          {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h16"}}},"boost":1}}]}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.streetName":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"nisra.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.welshThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"nisra.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"nisra.altThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.streetDescriptor":{"query":"h7","fuzziness":"1"}}},"boost":2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.postcodeLocator":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"postcodeOut":{"query":"h02p","fuzziness":"1"}}},{"match":{"postcodeIn":{"query":"h01p","fuzziness":"2"}}}]}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"paf.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"nisra.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h5","fuzziness":"1","minimum_should_match":"-45%"}}},"boost":2.5}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"lpi.paoStartNumber":{"query":"13"}}},{"match":{"lpi.paoStartSuffix":{"query":"h11"}}}]}},"boost":3}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"dis_max":{"tie_breaker":0,"boost":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.paoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h11"}}},"boost":1}}]}}]}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.organisation":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h3","minimum_should_match":"30%"}}},"boost":0.5}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"nisra.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"nisra.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"nisra.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"13"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartSuffix":{"query":"h11"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndNumber":{"query":"12"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndSuffix":{"query":"h14"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"nisra.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"nisra.paoStartNumber":{"query":"13"}}},"boost":0.1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndNumber":{"query":"17"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"17"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"token.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"nisra.nisraAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"nisra.nisraAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
+            {"query":{"dis_max":{"tie_breaker":1,"queries":[{"bool":{"should":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h4","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h16"}}},"boost":1}}]}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.streetName":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.thoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.welshThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":2}},{"constant_score":{"filter":{"match":{"paf.dependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentThoroughfare":{"query":"h7","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.streetDescriptor":{"query":"h7","fuzziness":"1"}}},"boost":2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postcode":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.postcodeLocator":{"query":"h10"}}},"boost":1}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"postcodeOut":{"query":"h02p","fuzziness":"1"}}},{"match":{"postcodeIn":{"query":"h01p","fuzziness":"2"}}}]}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"paf.buildingName":{"query":"h5","fuzziness":"1"}}},"boost":2.5}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h5","fuzziness":"1","minimum_should_match":"-45%"}}},"boost":2.5}},{"constant_score":{"filter":{"bool":{"must":[{"match":{"lpi.paoStartNumber":{"query":"13"}}},{"match":{"lpi.paoStartSuffix":{"query":"h11"}}}]}},"boost":3}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"dis_max":{"tie_breaker":0,"boost":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.buildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h5","minimum_should_match":"-45%"}}},"boost":1.5}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"13"}}},"boost":1}},{"constant_score":{"filter":{"match":{"tokens.paoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.subBuildingName":{"query":"h11"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h11"}}},"boost":1}}]}}]}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.organisationName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.organisation":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.paoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h2","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoText":{"query":"h2","minimum_should_match":"30%"}}},"boost":0.5}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.departmentName":{"query":"h3","minimum_should_match":"30%"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.legalName":{"query":"h3","minimum_should_match":"30%"}}},"boost":0.5}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h8","fuzziness":"1"}}},"boost":1}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h8","fuzziness":"1"}}},"boost":0.5}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h8","fuzziness":"1"}}},"boost":0.2}}]}},{"dis_max":{"tie_breaker":0,"queries":[{"constant_score":{"filter":{"match":{"tokens.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.postTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.welshPostTown":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"lpi.townName":{"query":"h20","fuzziness":"1"}}},"boost":0.2}},{"constant_score":{"filter":{"match":{"paf.dependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.welshDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"lpi.locality":{"query":"h20","fuzziness":"1"}}},"boost":0.6}},{"constant_score":{"filter":{"match":{"paf.doubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}},{"constant_score":{"filter":{"match":{"paf.welshDoubleDependentLocality":{"query":"h20","fuzziness":"1"}}},"boost":0.3}}]}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"tokens.paoStartNumber":{"query":"13"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"13"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartSuffix":{"query":"h11"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndNumber":{"query":"12"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoEndSuffix":{"query":"h14"}}},"boost":2}},{"constant_score":{"filter":{"match":{"lpi.paoStartNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"12"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"paf.buildingNumber":{"query":"13"}}},"boost":0.1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"15"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndNumber":{"query":"17"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoStartNumber":{"query":"17"}}},"boost":0.1}},{"constant_score":{"filter":{"match":{"token.saoStartSuffix":{"query":"h16"}}},"boost":1}},{"constant_score":{"filter":{"match":{"lpi.saoEndSuffix":{"query":"h18"}}},"boost":1}}]}},{"dis_max":{"tie_breaker":0.5,"queries":[{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"D"}}},"boost":1.2}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"C"}}},"boost":1.1}},{"constant_score":{"filter":{"match":{"lpi.addressBasePostal":{"query":"L"}}},"boost":1.1}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"minimum_should_match":"-40%"}},{"bool":{"must":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":8,"minimum_should_match":"-40%"}}},{"match":{"lpi.nagAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}},{"match":{"paf.pafAll":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","analyzer":"welsh_split_synonyms_analyzer","boost":1,"minimum_should_match":"-40%"}}}]}}],"should":[{"dis_max":{"tie_breaker":0,"queries":[{"match":{"tokens.addressAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":2,"fuzziness":"0"}}},{"match":{"lpi.nagAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}},{"match":{"paf.pafAll.bigram":{"query":"h2 h3 h4 h5 6 h7 h20 h8 h10","boost":0.4,"fuzziness":"0"}}}]}}],"filter":[{"terms":{"classificationCode":["RD06"]}}],"boost":0.5}}]}},"from":0,"size":1,"sort":[{"_score":{"order":"desc"}},{"uprn":{"order":"asc"}}],"track_scores":true}
         """.stripMargin)
 
       // When


### PR DESCRIPTION
The extra boost is just enough to nudge the addressBasePostal=N addresses down the list, except where they really are a better match. Note that this does seem to fix the property shell issue noted in the recent NLP testing.

I have also removed NISRA fields from the queries (breaking a lot of tests) but the aux ones (tokens.xxxx) are still there.